### PR TITLE
Use the +standalone helper to generate a standalone build

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,9 +5,12 @@ stealTools.export({
 		config: __dirname + "/package.json!npm"
 	},
 	outputs: {
-		"+cjs": {},
 		"+amd": {},
-		"+global-js": {}
+		"+standalone": {
+			exports: {
+				"can-util/namespace": "can"
+			}
+		}
 	}
 }).catch(function(e){
 	


### PR DESCRIPTION
And sets can-util/namespace to `window.can`.