### PR TITLE
Add breaking test for viewModel: Map

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -57,8 +57,23 @@ var Component = Construct.extend(
 
 				// Define a control using the `events` prototype property.
 				this.Control = ComponentControl.extend(this.prototype.events);
-				// Do nothing, assume constructor
-				this.ViewModel = this.prototype.ViewModel || types.DefaultMap;
+
+				// Backwards compatible with viewModel: Map
+				// If this a CanMap constructor, use that as the ViewModel property.
+				var protoViewModel = this.prototype.viewModel;
+
+				if(protoViewModel && this.prototype.ViewModel) {
+					throw new Error("Cannot provide both a ViewModel and a viewModel property");
+				}
+
+				if(protoViewModel && types.isMapLike(protoViewModel.prototype)) {
+					this.prototype.viewModel = undefined;
+				} else {
+					protoViewModel = undefined;
+				}
+
+				this.ViewModel = this.prototype.ViewModel ||
+					protoViewModel || types.DefaultMap;
 
 				// Convert the template into a renderer function.
 				if (this.prototype.template || this.prototype.view) {

--- a/test/component-map-test.js
+++ b/test/component-map-test.js
@@ -965,6 +965,21 @@ function makeTest(name, doc, mutObs) {
 		equal(fragTwo.firstChild.firstChild.nodeValue, "Matthew", "The second map did not change");
 	});
 
+	test("Providing viewModel and ViewModel throws", function() {
+		try {
+			Component.extend({
+				tag: "viewmodel-test",
+				template: stache("<div></div>"),
+				viewModel: {},
+				ViewModel: CanMap.extend({})
+			});
+
+			ok(false, "Should have thrown because we provided both");
+		} catch(er) {
+			ok(true, "It threw because we provided both viewModel and ViewModel");
+		}
+	});
+
 	test("content in a list", function () {
 		var template = stache('<my-list>{{name}}</my-list>');
 

--- a/test/component-map-test.js
+++ b/test/component-map-test.js
@@ -927,6 +927,44 @@ function makeTest(name, doc, mutObs) {
 
 	});
 
+	test("a CanMap constructor as viewModel", function() {
+		var MyMap = CanMap.extend({
+			name: "Matthew"
+		});
+
+		Component.extend({
+			tag: "can-map-viewmodel",
+			template: stache("{{name}}"),
+			viewModel: MyMap
+		});
+
+		var template = stache("<can-map-viewmodel></can-map-viewmodel>");
+		equal(template().firstChild.firstChild.nodeValue, "Matthew");
+	});
+
+	test("an object is turned into a CanMap as viewModel", function() {
+		Component.extend({
+			tag: "can-map-viewmodel",
+			template: stache("{{name}}"),
+			viewModel: {
+				name: "Matthew"
+			}
+		});
+
+		var template = stache("<can-map-viewmodel></can-map-viewmodel>");
+
+		var fragOne = template();
+		var vmOne = canViewModel(fragOne.firstChild);
+
+		var fragTwo = template();
+		var vmTwo = canViewModel(fragTwo.firstChild);
+
+		vmOne.attr("name", "Wilbur");
+
+		equal(fragOne.firstChild.firstChild.nodeValue, "Wilbur", "The first map changed values");
+		equal(fragTwo.firstChild.firstChild.nodeValue, "Matthew", "The second map did not change");
+	});
+
 	test("content in a list", function () {
 		var template = stache('<my-list>{{name}}</my-list>');
 


### PR DESCRIPTION
This adds a breaking test demonstrating that:

```js
var CustomMap = CanMap.extend({});

Component.extend({
	tag: "my-component",
	template: stache("{{name}}"),
	viewModel: CustomMap
});
```

Is not working, the `CustomMap` is not newed.