### PR TITLE
Allow bindings to be setup by the component's tagData

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -116,7 +116,12 @@ var Component = Construct.extend(
 			// ## Scope
 			var teardownBindings;
 			if (setupBindings) {
-				teardownBindings = stacheBindings.behaviors.viewModel(el, componentTagData, function(initialViewModelData) {
+				var setupFn = componentTagData.setupBindings ||
+					function(el, callback, data){
+						return stacheBindings.behaviors.viewModel(el, componentTagData,
+																											callback, data);
+					};
+				teardownBindings = setupFn(el, function(initialViewModelData) {
 					// Make %root available on the viewModel.
 					initialViewModelData["%root"] = componentTagData.scope.attr("%root");
 


### PR DESCRIPTION
This makes it so that the templating engine can provide a
`setupBindings` function on the component's `tagData` which will be used
to get the initial values from the element that will be used to
construct the View Model.

This is a 3-step fix. This initial commit makes it so that the
templating engine can provide a `setupBindings` function, but we still
fallback to can-stache-bindings if it doesn't exist. Step 2 will be to
update can-stache to provide it's own bindings using setupBindings. Step
3 will be to remove the dependency on can-stache-bindings from
can-component.

Part of #23