### PR TITLE
Increase timeout for IE10

### DIFF
--- a/test/component-map-test.js
+++ b/test/component-map-test.js
@@ -1793,12 +1793,12 @@ function makeTest(name, doc, mutObs) {
 			if(index < threads.length) {
 				threads[index]();
 				index++;
-				setTimeout(next, 10);
+				setTimeout(next, 50);
 			} else {
 				start();
 			}
 		};
-		setTimeout(next,10);
+		setTimeout(next, 50);
 	});
 
 	test("<content> (#2151)", function(){


### PR DESCRIPTION
It looks like `10` was treated as 0 in IE causing the attribute to not update in time.