### PR TITLE
Remove dependency on cssify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-component",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "canjs-plugin",
@@ -68,7 +58,6 @@
     "can-map": "^3.0.0-pre.7",
     "can-stache": "^3.0.0-pre.15",
     "can-vdom": "^3.0.0",
-    "cssify": "^1.0.2",
     "bit-docs": "0.0.6",
     "done-serve": "^0.2.5",
     "donejs-cli": "^0.9.5",


### PR DESCRIPTION
This removes cssify as a dependency since it is not used by this project
and it breaks Browserify usage.