### PR TITLE
Fix for custom tag: content is already defined

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -328,10 +328,6 @@ var Component = Construct.extend(
 		}
 	});
 
-// This was moved from the legacy view/scanner.js to here in prep for 3.0.0
-viewCallbacks.tag("content", function(el, tagData) {
-	return tagData.scope;
-});
 
 
 module.exports = namespace.Component = Component;


### PR DESCRIPTION
This fixes issue #90; which is to address the warning for content is already defined.