### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 doc/
 dist/
 .idea/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -41,18 +41,19 @@
     "can-compute": "^3.3.1",
     "can-construct": "^3.2.0",
     "can-control": "^3.2.0",
+    "can-globals": "^0.2.3",
     "can-namespace": "1.0.0",
     "can-observation": "^3.3.1",
     "can-reflect": "^1.2.1",
     "can-simple-map": "^3.3.0",
     "can-stache-bindings": "^3.4.0",
+    "can-stache-key": "0.1.0",
     "can-types": "^1.1.0",
     "can-util": "^3.9.5",
     "can-view-callbacks": "^3.2.0",
     "can-view-model": "^3.4.0",
     "can-view-nodelist": "^3.1.0",
-    "can-view-scope": "^3.3.1",
-    "can-stache-key": "0.1.0"
+    "can-view-scope": "^3.3.1"
   },
   "devDependencies": {
     "can-define": "^1.3.0",

--- a/test/component-map-test.js
+++ b/test/component-map-test.js
@@ -23,17 +23,17 @@ var types = require("can-types");
 
 var isPromise = require('can-util/js/is-promise/is-promise');
 
+var globals = require('can-globals');
 var makeDocument = require('can-vdom/make-document/make-document');
-var MUTATION_OBSERVER = require('can-util/dom/mutation-observer/mutation-observer');
-var DOCUMENT = require("can-util/dom/document/document");
+var getDocument = require("can-globals/document/document");
 var getFragment = require("can-util/dom/fragment/fragment");
 var Scope = require("can-view-scope");
 var viewCallbacks = require("can-view-callbacks");
 var canLog = require("can-util/js/log/log");
 
 
-var DOC = DOCUMENT();
-var MUT_OBS = MUTATION_OBSERVER();
+var DOC = getDocument();
+var MUT_OBS = globals.getKeyValue('MutationObserver');
 makeTest("can-component - map - dom", document, MUT_OBS);
 makeTest("can-component - map - vdom", makeDocument(), null);
 
@@ -60,8 +60,10 @@ function makeTest(name, doc, mutObs) {
 	var oldDoc, oldDefaultMap;
 	QUnit.module(name, {
 		setup: function () {
-			DOCUMENT(doc);
-			MUTATION_OBSERVER(mutObs);
+			getDocument(doc);
+			if(!mutObs){
+				globals.setKeyValue('MutationObserver', mutObs);
+			}
 
 			oldDefaultMap = types.DefaultMap;
 			types.DefaultMap = CanMap;
@@ -79,8 +81,8 @@ function makeTest(name, doc, mutObs) {
 			setTimeout(function(){
 				types.DefaultMap = oldDefaultMap;
 				start();
-				DOCUMENT(DOC);
-				MUTATION_OBSERVER(MUT_OBS);
+				getDocument(DOC);
+				globals.deleteKeyValue('MutationObserver');
 			}, 100);
 		}
 	});
@@ -1695,7 +1697,7 @@ function makeTest(name, doc, mutObs) {
 	});
 
 	test("custom renderer can provide setupBindings", function(){
-		DOCUMENT(document);
+		getDocument(document);
 		var rendererFactory = function(tmpl){
 			var frag = getFragment(tmpl);
 			return function(scope, options){


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.