### PR TITLE
Helpers respect leakscope

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -302,8 +302,6 @@ var Component = Construct.extend(
 					options.helpers[prop] = val.bind(viewModel);
 				}
 			});
-			var optionsScopeWithHelpers = componentTagData.options.add(options);
-
 
 			// ## `events` control
 
@@ -339,7 +337,7 @@ var Component = Construct.extend(
 						scope: componentTagData.scope.add(new Scope.Refs()).add(this.viewModel, {
 							viewModel: true
 						}),
-						options: optionsScopeWithHelpers
+						options: componentTagData.options.add(options)
 					};
 
 				} else { // lexical
@@ -348,7 +346,7 @@ var Component = Construct.extend(
 						scope: Scope.refsScope().add(this.viewModel, {
 							viewModel: true
 						}),
-						options: optionsScopeWithHelpers
+						options: new Scope.Options(options)
 					};
 				}
 
@@ -372,7 +370,7 @@ var Component = Construct.extend(
 					scope: componentTagData.scope.add(this.viewModel, {
 						viewModel: true
 					}),
-					options: optionsScopeWithHelpers
+					options: componentTagData.options.add(options)
 				};
 				betweenTagsTagData = lightTemplateTagData;
 				betweenTagsRenderer = componentTagData.subtemplate || el.ownerDocument.createDocumentFragment.bind(el.ownerDocument);

--- a/test/component-define-test.js
+++ b/test/component-define-test.js
@@ -88,11 +88,12 @@ QUnit.test('33 - works when instantiated with an object for ViewModel', function
 
 });
 
-QUnit.test("helpers do not leak when leakscope is false", function () {
+QUnit.test("helpers do not leak when leakscope is false (#77)", function () {
 	var called = 0;
 	var inner = Component.extend({
 		tag: "inner-el",
-		view: stache("inner{{test}}")
+		view: stache("inner{{test}}"),
+		leakScope: false
 	});
 	var outer = Component.extend({
 		tag: "outer-el",
@@ -102,14 +103,37 @@ QUnit.test("helpers do not leak when leakscope is false", function () {
 				called++;
 				return "heyo";
 			}
-		},
-		leakscope: false
+		}
 	});
 
 	var renderer = stache("<outer-el>");
 
 	renderer();
 	QUnit.equal(called, 0, "Outer helper not called");
+});
+
+QUnit.test("helpers do leak when leakscope is true (#77)", function () {
+	var called = 0;
+	var inner = Component.extend({
+		tag: "inner-el",
+		view: stache("inner{{test}}"),
+		leakScope: true
+	});
+	var outer = Component.extend({
+		tag: "outer-el",
+		view: stache("outer:<inner-el>"),
+		helpers: {
+			test: function () {
+				called++;
+				return "heyo";
+			}
+		}
+	});
+
+	var renderer = stache("<outer-el>");
+
+	renderer();
+	QUnit.equal(called, 1, "Outer helper called once");
 });
 
 if(System.env.indexOf("production") < 0) {

--- a/test/component-define-test.js
+++ b/test/component-define-test.js
@@ -71,7 +71,7 @@ QUnit.test('scope method works', function () {
 });
 
 QUnit.test('33 - works when instantiated with an object for ViewModel', function () {
-	
+
 	Component.extend({
 		tag: "test-element",
 		view: stache("{{someMethod}}"),
@@ -81,12 +81,35 @@ QUnit.test('33 - works when instantiated with an object for ViewModel', function
 				return true;
 			}
 		}
-		
 	});
-	
+
 	var renderer = stache("<test-element>");
 	renderer();
 
+});
+
+QUnit.test("helpers do not leak when leakscope is false", function () {
+	var called = 0;
+	var inner = Component.extend({
+		tag: "inner-el",
+		view: stache("inner{{test}}")
+	});
+	var outer = Component.extend({
+		tag: "outer-el",
+		view: stache("outer:<inner-el>"),
+		helpers: {
+			test: function () {
+				called++;
+				return "heyo";
+			}
+		},
+		leakscope: false
+	});
+
+	var renderer = stache("<outer-el>");
+
+	renderer();
+	QUnit.equal(called, 0, "Outer helper not called");
 });
 
 if(System.env.indexOf("production") < 0) {


### PR DESCRIPTION
Resolves #77

Helpers functions would get passed to a child component even when leakScope was true. Helpers now respect the leakScope value and, when false, will not be available to child components views.

- Added test for helper leak scope
- Fixed bug in can-component