### PR TITLE
Update docs to use the new binding syntax

### DIFF
--- a/docs/ViewModel.md
+++ b/docs/ViewModel.md
@@ -32,11 +32,11 @@ Use [can-view-model] to read a component’s view model instance.
 
 The view bindings on a tag control the properties and values used to instantiate the `ViewModel`. For example, calling `<my-tag>` as follows invokes `MyTagViewModel` as shown in the following example:
 
-```
+```html
 <my-tag/> <!-- new MyTagViewModel({}) -->
 
 <my-tag
-	{message}="'Hi There'"/> <!-- new MyTagViewModel({message: "Hi There"}) -->
+	message:from="'Hi There'"/> <!-- new MyTagViewModel({message: "Hi There"}) -->
 ```
 
 @return {Object} A new instance of the corresponding constructor function. This instance is
@@ -68,16 +68,21 @@ Component.extend({
 ```
 
 If this component HTML was inserted into the page like:
+
 ```js
 var renderer = stache("<my-paginate/>");
 var frag = renderer();
 document.body.appendChild(frag);
 ```
+
 It would result in:
 
-    <my-paginate>Page 1</my-paginate>
+```html
+<my-paginate>Page 1</my-paginate>
+```
 
 This is because the provided ViewModel object is used to create an instance of [can-define/map/map] like:
+
 ```js
 var viewModel = new MyPaginateViewModel();
 ```
@@ -88,9 +93,10 @@ Next, the values are passed into `viewModel` from the [can-stache-bindings data 
 (in this case there is none).
 
 And finally, that data is used to render the component’s view and inserted into the element using [can-view-scope] and [can-stache]:
+
 ```js
-var newViewModel = new Scope(viewModel),
-	result = stache("Page {{page}}.")(newViewModel);
+var newViewModel = new Scope(viewModel);
+var result = stache("Page {{page}}.")(newViewModel);
 element.innerHTML = result;
 ```
 
@@ -100,6 +106,7 @@ by setting the Component’s ViewModel to an object and using
 that anonymous type as the view model.
 
 The following does the same as above:
+
 ```js
 Component.extend({
 	tag: "my-paginate",
@@ -125,11 +132,14 @@ Values can be "passed" into the viewModel instance of a component, similar to pa
 
 Using [can-stache], values are passed into components like this:
 
-    <my-paginate {offset}='index' {limit}='size' />
+```html
+<my-paginate offset:from='index' limit:from='size' />
+```
 
 The above creates an offset and limit property on the component that are initialized to whatever index and size are.
 
 The following component requires an `offset` and `limit`:
+
 ```js
 Component.extend({
 	tag: "my-paginate",
@@ -143,31 +153,40 @@ Component.extend({
 	view: stache("Page {{page}}.")
 });
 ```
+
 If `<my-paginate>` is used like:
+
 ```js
-var renderer = stache("<my-paginate {offset}='index' {limit}='size' />");
+var renderer = stache("<my-paginate offset:from='index' limit:from='size' />");
 
 var pageInfo = new DefineMap({index: 0, size: 20});
 
 document.body.appendChild(renderer(pageInfo));
 ```
-... `pageInfo`’s index and size are set as the component’s offset and
+
+…`pageInfo`’s index and size are set as the component’s offset and
 limit attributes. If we were to change the value of `pageInfo`’s
 index like:
+
 ```js
 pageInfo.index = 20;
 ```
-... the component’s offset value will change and its view will update to:
 
-    <my-paginate>Page 2</my-paginate>
+…the component’s offset value will change and its view will update to:
+
+```html
+<my-paginate>Page 2</my-paginate>
+```
 
 ### Using attribute values
 
 You can also pass a literal string value of the attribute. To do this in [can-stache],
-simply pass any value not wrapped in single brackets, and the viewModel instance property will
+simply pass a quoted value not wrapped in single brackets, and the viewModel instance property will
 be initialized to this string value:
 
-    <my-tag title="hello" />
+```html
+<my-tag title:from="'hello'" />
+```
 
 The above will set the title property on the component’s viewModel instance to the string `hello`.
 
@@ -184,7 +203,6 @@ out.addEventListener("click", function(ev){
 	var parent = el.parentNode;
 	if(el.nodeName === "BUTTON") {
 		parent.setAttribute("title", "Users");
-		parent.removeChild(el);
 	}
 });
 ```
@@ -210,7 +228,7 @@ var ViewModel = DefineMap.extend({
 Component.extend({
 	tag: "my-paginate",
 	ViewModel: ViewModel,
-	view: stache("Page {{page}} <button ($click)='next()'>Next</button>")
+	view: stache("Page {{page}} <button on:click='next()'>Next</button>")
 });
 ```
 
@@ -239,10 +257,10 @@ Component.extend({
 
 These can be listened to with [can-stache-bindings.event] bindings like:
 
-```js
+```html
 <player-edit
-  	(close)="removeEdit()"
-  	{player}="editingPlayer" />
+	on:close="removeEdit()"
+	player:from="editingPlayer" />
 ```
 
 The following demo uses this ability to create a close button that

--- a/docs/beforeremove.md
+++ b/docs/beforeremove.md
@@ -33,8 +33,8 @@ events: {
 Uses [can-stache-bindings.event] bindings to listen for a component’s
 `beforeremove` event.
 
-```
-<my-panel ($beforeremove)="removePanel(%viewModel)"/>
+```html
+<my-panel on:beforeremove="removePanel(scope.viewModel)"/>
 ```
 
   @param {can-stache/expressions/call} CALL_EXRESSION A call expression that calls some method when the event happens.

--- a/docs/can-slot.md
+++ b/docs/can-slot.md
@@ -147,7 +147,6 @@ Default content can be specified to be used if there is no matching `<can-templa
 or the matching `<can-template>` has no inner content.
 
 ```js
-
 Component.extend({
 	tag : 'my-email',
 	view : stache(

--- a/docs/component.md
+++ b/docs/component.md
@@ -50,7 +50,7 @@ a [can-component/can-template] that is used to render the search results:
 
    Example:
 
-   ```
+   ```html
    <my-tag getChild:from="expression"
            setParent:to="expression"
            twoWay:bind="expression"
@@ -80,7 +80,7 @@ a [can-component/can-template] that is used to render the search results:
    @param {can-stache.sectionRenderer} [LIGHT_DOM] The content between the starting and ending
    tag. For example, `Hello <b>World</b>` is the `LIGHT_DOM` in the following:
 
-   ```
+   ```html
    <my-tag>Hello <b>World</b></my-tag>
    ```
 
@@ -124,8 +124,10 @@ says “Hello There!”.  To create an instance of this component on the page,
 add `<hello-world/>` to a [can-stache] view, render
 the view, and insert the result in the page like:
 
-    var renderer = stache("<hello-world/>");
-    document.body.appendChild(renderer({ }));
+```js
+var renderer = stache("<hello-world/>");
+document.body.appendChild(renderer({ }));
+```
 
 Check this out here:
 
@@ -135,15 +137,17 @@ Check this out here:
 Typically, you do not append a single component at a time.  Instead,
 you'll render a view with many custom tags like:
 
-    <srchr-app>
-      <srchr-search models:from="models">
-        <input name="search"/>
-      </srchr-search>
-      <ui-panel>
-        <srchr-history/>
-        <srchr-results {models}="models"/>
-      </ui-panel>
-    </srchr-app>
+```html
+<srchr-app>
+  <srchr-search models:from="models">
+    <input name="search"/>
+  </srchr-search>
+  <ui-panel>
+    <srchr-history/>
+    <srchr-results models:from="models"/>
+  </ui-panel>
+</srchr-app>
+```
 
 ### Defining a Component
 
@@ -165,9 +169,11 @@ the component will be created on.
 
 The following matches `<hello-world>` elements.
 
-    Component.extend({
-      tag: "hello-world"
-    });
+```js
+Component.extend({
+  tag: "hello-world"
+});
+```
 
 ### View
 
@@ -176,27 +182,35 @@ the element’s innerHTML.
 
 The following component:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("<h1>Hello World</h1>")
-    });
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("<h1>Hello World</h1>")
+});
+```
 
 Changes `<hello-world/>` elements into:
 
-    <hello-world><h1>Hello World</h1></hello-world>
+```html
+<hello-world><h1>Hello World</h1></hello-world>
+```
 
 Use the [can-component/content] tag to position the custom element’s source HTML.
 
 The following component:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("<h1><content/></h1>")
-    });
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("<h1><content/></h1>")
+});
+```
 
 Changes `<hello-world>Hi There</hello-world>` into:
 
-    <hello-world><h1>Hi There</h1></hello-world>
+```html
+<hello-world><h1>Hi There</h1></hello-world>
+```
 
 ### ViewModel
 
@@ -208,52 +222,68 @@ of the custom element and added to the viewModel object.
 
 The following component:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("<h1>{{message}}</h1>")
-    });
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("<h1>{{message}}</h1>")
+});
+```
 
 Changes the following rendered view:
 
-    var renderer = stache("<hello-world message:from='greeting'/>");
-    renderer({
-      greeting: "Salutations"
-    })
+```js
+var renderer = stache("<hello-world message:from='greeting'/>");
+renderer({
+  greeting: "Salutations"
+});
+```
 
 Into:
 
-    <hello-world><h1>Salutations</h1></hello-world>
+```html
+<hello-world><h1>Salutations</h1></hello-world>
+```
 
 Default values can be provided. The following component:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("<h1>{{message}}</h1>"),
-      viewModel: {
-        message: "Hi"
-      }
-    });
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("<h1>{{message}}</h1>"),
+  viewModel: {
+    message: "Hi"
+  }
+});
+```
 
 Changes the following rendered view:
 
-    var renderer = stache("<hello-world/>");
-    renderer({})
+```js
+var renderer = stache("<hello-world/>");
+renderer({});
+```
 
 Into:
 
-    <hello-world><h1>Hi</h1></hello-world>
+```html
+<hello-world><h1>Hi</h1></hello-world>
+```
 
 If you want to set the string value of the attribute on the ViewModel,
 set an attribute without any binding syntax.
 
 The following view, with the previous `hello-world` component:
 
-    var renderer = stache("<hello-world message='Howdy'/>");
-    renderer({})
+```js
+var renderer = stache("<hello-world message='Howdy'/>");
+renderer({});
+```
 
 Renders:
 
-    <hello-world><h1>Howdy</h1></hello-world>
+```html
+<hello-world><h1>Howdy</h1></hello-world>
+```
 
 ### Events
 
@@ -261,16 +291,18 @@ A component’s [can-component::events events] object is used to listen to event
 listened to with [can-stache-bindings view bindings]). The following component
 adds “!” to the message every time `<hello-world>` is clicked:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("<h1>{{message}}</h1>"),
-      events: {
-        "click" : function(){
-          var currentMessage = this.viewModel.message;
-          this.viewModel.message = currentMessage+ "!";
-        }
-      }
-    });
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("<h1>{{message}}</h1>"),
+  events: {
+    "click" : function(){
+      var currentMessage = this.viewModel.message;
+      this.viewModel.message = currentMessage+ "!";
+    }
+  }
+});
+```
 
 Components have the ability to bind to special [can-util/dom/events/inserted/inserted],
 [can-component/beforeremove] and [can-util/dom/events/removed/removed] events
@@ -283,21 +315,23 @@ A component’s [can-component::helpers helpers] object provides [can-stache.hel
 that are available within the component’s view.  The following component
 only renders friendly messages:
 
-    Component.extend({
-      tag: "hello-world",
-      view: stache("{{#isFriendly message}}"+
-                  "<h1>{{message}}</h1>"+
-                "{{/isFriendly}}"),
-      helpers: {
-        isFriendly: function(message, options){
-          if( /hi|hello|howdy/.test(message) ) {
-            return options.fn();
-          } else {
-            return options.inverse();
-          }
-        }
+```js
+Component.extend({
+  tag: "hello-world",
+  view: stache("{{#isFriendly message}}"+
+              "<h1>{{message}}</h1>"+
+            "{{/isFriendly}}"),
+  helpers: {
+    isFriendly: function(message, options){
+      if( /hi|hello|howdy/.test(message) ) {
+        return options.fn();
+      } else {
+        return options.inverse();
       }
-    });
+    }
+  }
+});
+```
 
 Generally speaking, helpers should only be used for view related functionality, like
 formatting a date.  Data related methods should be in the view model or models.
@@ -316,25 +350,30 @@ to add a new tab.
 An instance of the tabs widget is created by creating `<my-tabs>` and `<my-panel>`
 elements like:
 
-    <my-tabs>
-      {{#each foodTypes}}
-        <my-panel title='title'>{{content}}</my-panel>
-      {{/each}}
-    </my-tabs>
+```html
+<my-tabs>
+  {{#each foodTypes}}
+    <my-panel title:from='title'>{{content}}</my-panel>
+  {{/each}}
+</my-tabs>
+```
 
 To add another panel, all we have to do is add data to `foodTypes` like:
 
-    foodTypes.push({
-      title: "Vegetables",
-      content: "Carrots, peas, kale"
-    })
+```js
+foodTypes.push({
+  title: "Vegetables",
+  content: "Carrots, peas, kale"
+});
+```
 
 The secret is that the `<my-panel>` element listens to when it is inserted
 and adds its data to the tabs' list of panels with:
 
-    var vm = this.parentViewModel = canViewModel(this.element.parentNode);
-    vm.addPanel(this.viewModel);
-
+```js
+var vm = this.parentViewModel = canViewModel(this.element.parentNode);
+vm.addPanel(this.viewModel);
+```
 
 ### TreeCombo
 
@@ -346,7 +385,7 @@ The secret to this widget is the viewModel’s `breadcrumb` property, which is a
 of items the user has navigated through, and `selectableItems`, which represents the children of the
 last item in the breadcrub.  These are defined on the viewModel like:
 
-
+```js
     breadcrumb: [],
     selectableItems: function(){
       var breadcrumb = this.attr("breadcrumb");
@@ -362,14 +401,17 @@ last item in the breadcrub.  These are defined on the viewModel like:
         return this.attr('items');
       }
     }
+```
 
 When the “+” icon is clicked next to each item, the viewModel’s `showChildren` method is called, which
 adds that item to the breadcrumb like:
 
+```js
     showChildren: function(item, ev) {
       ev.stopPropagation();
       this.attr('breadcrumb').push(item)
     },
+```
 
 ### Paginate
 
@@ -380,9 +422,11 @@ widget-like components: a grid, next / prev buttons, and a page count indicator.
 
 This demo uses a `Paginate` [can-define/map/map] to assist with maintaining a paginated state:
 
-    var Paginate = DefineMap.extend({
-    ...
-    });
+```js
+var Paginate = DefineMap.extend({
+  ...
+});
+```
 
 The `app` component, using [can-define/map/map], creates an instance of the `Paginate` model
 and a `websitesPromise` that represents a request for the Websites
@@ -421,15 +465,17 @@ var AppViewModel = DefineMap.extend({
 The `my-app` component passes paginate, paginate’s values, and websitesPromise to
 its sub-components:
 
-    <my-app>
-      <my-grid promiseData:from='websitesPromise'>
-        {{#each items}}
-          <tr>
-            <td width='40%'>{{name}}</td>
-            <td width='70%'>{{url}}</td>
-          </tr>
-        {{/each}}
-      </my-grid>
-      <next-prev paginate:from='paginate'></next-prev>
-      <page-count page:from='paginate.page' count:from='paginate.pageCount'/>
-    </my-app>
+```html
+<my-app>
+  <my-grid promiseData:from='websitesPromise'>
+    {{#each items}}
+      <tr>
+        <td width='40%'>{{name}}</td>
+        <td width='70%'>{{url}}</td>
+      </tr>
+    {{/each}}
+  </my-grid>
+  <next-prev paginate:from='paginate'></next-prev>
+  <page-count page:from='paginate.page' count:from='paginate.pageCount'/>
+</my-app>
+```

--- a/docs/content.md
+++ b/docs/content.md
@@ -8,14 +8,14 @@ Positions the `LIGHT_DOM` within a component’s [can-component.prototype.view].
 When a user creates a new component in a view, the content between the tags is the
 `LIGHT_DOM`.  For example, `Hello <b>World</b>` is the `LIGHT_DOM` in the following:
 
-```
+```html
 <my-tag>Hello <b>World</b></my-tag>
 ```
 
 The `<content>` tag can be used within `my-tag` to position the `LIGHT_DOM`.  For
 example, to position the `LIGHT_DOM` within an `<h1>`, `<my-tag>` could be defined like:
 
-```
+```js
 Component.extend({
 	tag: "my-tag",
 	view: stache("<h1><content/></h1>")
@@ -27,7 +27,7 @@ Component.extend({
 
    The following, makes `my-tag` show `Hi There!` if no `LIGHT_DOM` is passed:
 
-   ```
+   ```js
    Component.extend({
    	tag: "my-tag",
    	view: stache("<h1><content>Hi There!</content></h1>")

--- a/docs/events.md
+++ b/docs/events.md
@@ -6,24 +6,25 @@ Listen to events on elements and observables.
 @option {Object.<can-control.eventDescription,can-control.eventHandler>} An object of event names and methods
 that handle the event. For example:
 
-    Component.extend({
-	  ViewModel: {
+```js
+Component.extend({
+	ViewModel: {
 		limit: "number",
 		offset: "number",
-	    next: function(){
-	      this.offset = this.offset + this.limit;
-	    }
-	  },
-      events: {
-        ".next click": function(){
-          this.viewModel.next()
-        },
-		"{viewModel} limit": function(viewModel, ev, newValue){
-		  console.log("limit is now", newValue);
+		next: function(){
+			this.offset = this.offset + this.limit;
 		}
-      }
-    })
-
+	},
+	events: {
+		".next click": function(){
+			this.viewModel.next()
+		},
+		"{viewModel} limit": function(viewModel, ev, newValue){
+			console.log("limit is now", newValue);
+		}
+	}
+});
+```
 
 A component’s events object is used as the prototype of a [can-control]. The control gets created on the component’s
 element.
@@ -50,21 +51,25 @@ of using live-binding, we could listen to when offset changes and update the pag
 
 Components have the ability to bind to special inserted and removed events that are called when a component’s tag has been inserted into or removed from the page:
 
-      events: {
-        "inserted": function(){
-          // called when the component’s tag is inserted into the DOM
-        },
-        "removed": function(){
-          // called when the component’s tag is removed from the DOM
-        }
-      }
+```js
+			events: {
+				"inserted": function(){
+					// called when the component’s tag is inserted into the DOM
+				},
+				"removed": function(){
+					// called when the component’s tag is removed from the DOM
+				}
+			}
+```
 
 ## High performance view rendering
 
 While [can-stache-bindings] conveniently allows you to call a [can-component::ViewModel] method from a view like:
 
-    <input ($change)="doSomething()"/>
+```html
+<input ($change)="doSomething()"/>
+``
 
-This has the effect of binding an event handler directly to this element. Every element that has a `($click)` or similar attribute has an event handler bound to it. For a large grid or list, this could have a performance penalty.
+This has the effect of binding an event handler directly to this element. Every element that has a `on:click` or similar attribute has an event handler bound to it. For a large grid or list, this could have a performance penalty.
 
 By contrast, events bound using [can-component]’s events object use event delegation, which is useful for high performance view rendering. In a large grid or list, event delegation only binds a single event handler rather than one per row.

--- a/docs/leakscope.md
+++ b/docs/leakscope.md
@@ -16,7 +16,8 @@ a component’s viewModel values in the user content.
 
 The default value is `false`.
 
-To change leakScope from the default
+To change leakScope from the default:
+
 ```js
 Component.extend({
 	tag: "my-component",
@@ -43,7 +44,7 @@ Let’s define what __outer scope__, __component’s view__ and __user content__
 
 If I have a `<hello-world>` component in a view like:
 
-```
+```html
 {{#data}}
 	<hello-world>{{subject}}</hello-world>
 {{/data}}
@@ -55,7 +56,7 @@ is `{{subject}}`.
 
 Finally, if `<hello-world>` is defined like:
 
-```
+```js
 Component.extend({
   tag: "hello-world",
   view: stache("{{greeting}} <content/>{{exclamation}}")
@@ -70,6 +71,7 @@ If `leakScope` is `true`, the __component’s view__ can read the data in the ou
 see `name: "John"` overwriting `name: "World"` in the component’s viewModel instance in the following example.
 
 If the following component is defined:
+
 ```js
 Component.extend({
 	tag: 'hello-world',
@@ -78,21 +80,30 @@ Component.extend({
 	view: stache("Hello {{name}}")
 });
 ```
+
 With this data in the outer scope:
+
 ```js
 { name: "John" }
 ```
+
 And used like so:
 
-    <hello-world />
+```html
+<hello-world />
+```
 
 If `leakScope` is `true` it will render:
 
-    <hello-world>Hello John</hello-world>
+```html
+<hello-world>Hello John</hello-world>
+```
 
 If `leakScope` is `false` it will render:
 
-    <hello-world>Hello World</hello-world>
+```html
+<hello-world>Hello World</hello-world>
+```
 
 ## Using viewModel in user content
 
@@ -100,6 +111,7 @@ if `leakScope` is `true`, the __user content__ is able to see the name property 
 viewModel instance in the following example. Else, name won't be seen.
 
 If the following component is defined:
+
 ```js
 Component.extend({
 	tag: 'hello-world',
@@ -108,14 +120,21 @@ Component.extend({
 	view: stache("Hello <content />")
 });
 ```
+
 And used like so:
 
-    <hello-world>{{name}}</hello-world>
+```html
+<hello-world>{{name}}</hello-world>
+```
 
 If `leakScope` is `true` it will render:
 
-    <hello-world>Hello World</hello-world>
+```html
+<hello-world>Hello World</hello-world>
+```
 
 If `leakScope` is `false` it will render:
 
-    <hello-world>Hello </hello-world>
+```html
+<hello-world>Hello </hello-world>
+```

--- a/docs/view-model.md
+++ b/docs/view-model.md
@@ -15,7 +15,7 @@ is rendered with.
 This is typically used only for special situations where a custom scope or custom bindings
 need to be setup.
 
-```
+```js
 var Component = require("can-component");
 var Scope = require("can-view-scope");
 
@@ -28,7 +28,7 @@ Component.extend({
 	}
 });
 
-stache("<my-element {first}='firstName' last='Meyer'/>")({
+stache("<my-element first:from='firstName' last='Meyer'/>")({
   firstName: "Justin",
   middleName: "Barry"
 });
@@ -36,18 +36,22 @@ stache("<my-element {first}='firstName' last='Meyer'/>")({
 
 @param {Object} properties An object of values specified by the custom element’s attributes. For example, a view rendered like:
 
-    stache("<my-element title='name'></my-element>")({
-      name: "Justin"
-    })
+```js
+stache("<my-element title:from='name'></my-element>")({
+  name: "Justin"
+});
+```
 
 Creates an instance of following control:
 
-    Component.extend({
-    	tag: "my-element",
-    	viewModel: function(properties){
-    	  properties.title //-> "Justin";
-    	}
-    })
+```js
+Component.extend({
+	tag: "my-element",
+	viewModel: function(properties){
+	  properties.title //-> "Justin";
+	}
+});
+```
 
 And calls the viewModel function with `properties` like `{title: "Justin"}`.
 
@@ -57,28 +61,32 @@ The viewModel the custom tag was found within.  By default, any attribute’s va
 be looked up within the current viewModel, but if you want to add values without needing
 the user to provide an attribute, you can set this up here.  For example:
 
-    Component.extend({
-    	tag: "my-element",
-    	viewModel: function(properties, parentScope){
-    	  parentScope.get('middleName') //-> "Barry"
-    	}
-    });
+```js
+Component.extend({
+	tag: "my-element",
+	viewModel: function(properties, parentScope){
+	  parentScope.get('middleName') //-> "Barry"
+	}
+});
+```
 
 Notice how the `middleName` value is looked up in `my-element`’s parent scope.
 
 @param {HTMLElement} element The element the [can-component] is going to be placed on. If you want
 to add custom attribute handling, you can do that here.  For example:
 
-    Component.extend({
-    	tag: "my-element",
-    	viewModel: function(properties, parentScope, el){
-		  var vm = new DefineMap({clicks: 0});
-    	  domEvent.addEventListener.call(el, "click", function(){
-		    vm.clicks++;
-		  });
-		  return vm;
-    	}
-    });
+```js
+Component.extend({
+	tag: "my-element",
+	viewModel: function(properties, parentScope, el){
+		var vm = new DefineMap({clicks: 0});
+		domEvent.addEventListener.call(el, "click", function(){
+			vm.clicks++;
+		});
+		return vm;
+	}
+});
+```
 
 This example should be done with the [can-component::events] object instead.
 

--- a/docs/view.md
+++ b/docs/view.md
@@ -6,11 +6,12 @@ component’s [can-component::ViewModel] instance.  `<content/>` elements within
 
 @option {can-stache.renderer} A [can-stache.renderer] returned by [can-stache]. For example:
 
-    Component({
-      tag: "my-tabs",
-      view: stache("<ul>{{#panels}}<li>{{title}}</li> ...")
-    });
-
+```js
+Component({
+  tag: "my-tabs",
+  view: stache("<ul>{{#panels}}<li>{{title}}</li> ...")
+});
+```
 
 @body
 
@@ -74,19 +75,23 @@ Notice:
 
 __Source data:__
 
-		stache("...")({
-			site: "CanJS"
-		})
+```js
+stache("...")({
+	site: "CanJS"
+});
+```
 
 This is how we render the source view that uses `<my-greeting>`. The view is rendered with `site` in its [can-component::ViewModel].
 
 __HTML Result:__
 
-    <header>
-      <my-greeting>
-        <h1>CanJS - can-component</h1>
-      </my-greeting>
-    </header>
+```html
+<header>
+  <my-greeting>
+    <h1>CanJS - can-component</h1>
+  </my-greeting>
+</header>
+```
 
 This is the result of the view transformations. The
 __user__ content within the original `<my-greeting>` is placed within the start of the `<h1>`
@@ -102,34 +107,44 @@ The view specified by `view` is rendered directly within the custom tag.
 
 For example the following component:
 
-    Component({
-      tag: "my-greeting",
-      view: stache("<h1>Hello There</h1>")
-    });
+```js
+Component({
+  tag: "my-greeting",
+  view: stache("<h1>Hello There</h1>")
+});
+```
 
 With the following source html:
 
-    <header>
-      <my-greeting></my-greeting>
-    </header>
+```html
+<header>
+  <my-greeting></my-greeting>
+</header>
+```
 
 Produces the following html:
 
-    <header>
-      <my-greeting><h1>Hello There</h1></my-greeting>
-    </header>
+```html
+<header>
+  <my-greeting><h1>Hello There</h1></my-greeting>
+</header>
+```
 
 However, if there was existing content within the source html, like:
 
-    <header>
-      <my-greeting>DO REMOVE ME!!!</my-greeting>
-    </header>
+```html
+<header>
+  <my-greeting>DO REMOVE ME!!!</my-greeting>
+</header>
+```
 
-that content is removed, and replaced by the component’s view:
+…that content is removed and replaced by the component’s view:
 
-    <header>
-      <my-greeting><h1>Hello There</h1></my-greeting>
-    </header>
+```html
+<header>
+  <my-greeting><h1>Hello There</h1></my-greeting>
+</header>
+```
 
 ### The `<content>` element
 
@@ -137,18 +152,24 @@ Use the `<content>` element to place the source content in the
 component’s element within the component’s
 view. For example, if we change the component to look like:
 
-    Component({
-      tag: "my-greeting",
-      view: stache("<h1><content/></h1>")
-    });
+```js
+Component({
+  tag: "my-greeting",
+  view: stache("<h1><content/></h1>")
+});
+```
 
 and rendered with source html, like:
 
-    <my-greeting>Hello World</my-greeting>
+```html
+<my-greeting>Hello World</my-greeting>
+```
 
 it produces:
 
-    <my-greeting><h1>Hello World</h1></my-greeting>
+```html
+<my-greeting><h1>Hello World</h1></my-greeting>
+```
 
 ### `<content>` element default content
 
@@ -156,15 +177,21 @@ If the user does not provide source content, the html
 between the `<content>` tags will be used. For example, if we
 change the component to look like:
 
-    Component({
-      tag: "my-greeting",
-      view: stache("<h1><content>Hello World</content></h1>")
-    });
+```js
+Component({
+  tag: "my-greeting",
+  view: stache("<h1><content>Hello World</content></h1>")
+});
+```
 
 and rendered with source html like:
 
-    <my-greeting></my-greeting>
+```html
+<my-greeting></my-greeting>
+```
 
 it produces:
 
-    <my-greeting><h1>Hello World</h1></my-greeting>
+```html
+<my-greeting><h1>Hello World</h1></my-greeting>
+```


### PR DESCRIPTION
A lot of the code examples didn’t have their type defined, so they were missed when can-migrate was used.