### PR TITLE
Handle elements with preventDataBindings set to true

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -295,6 +295,8 @@ var Component = Construct.extend(
 					viewModel = viewModelInstance;
 					return viewModelInstance;
 				}, initialViewModelData);
+			} else {
+				viewModel = domData.get.call(el, "viewModel");
 			}
 
 			// Set `viewModel` to `this.viewModel` and set it to the element's `data` object as a `viewModel` property
@@ -392,7 +394,7 @@ var Component = Construct.extend(
 
 
 			var disconnectedCallback;
-			if(viewModel.connectedCallback) {
+			if(viewModel && viewModel.connectedCallback) {
 				if(componentTagData.mounted === true) {
 					disconnectedCallback = viewModel.connectedCallback(el);
 				} else {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "can-view-scope": "^4.0.0-pre.34"
   },
   "devDependencies": {
-    "can-observe": "^2.0.0-pre.15",
     "can-define": "^2.0.0-pre.18",
+    "can-dom-data-state": "^0.2.0",
+    "can-observe": "^2.0.0-pre.15",
     "can-stache": "^4.0.0-pre.21",
     "can-symbol": "^1.4.1",
     "can-vdom": "^3.1.0",

--- a/test/component-viewmodel-test.js
+++ b/test/component-viewmodel-test.js
@@ -1,5 +1,6 @@
 var QUnit = require("steal-qunit");
 
+var canData = require('can-dom-data-state');
 var helpers = require("./helpers");
 var SimpleMap = require("can-simple-map");
 var stache = require("can-stache");
@@ -9,12 +10,14 @@ var domData = require('can-util/dom/data/data');
 var DefineMap = require('can-define/map/map');
 var DefineList = require("can-define/list/list");
 var domEvents = require('can-util/dom/events/events');
+var Scope = require("can-view-scope");
 var SetterObservable = require("can-simple-observable/setter/setter");
 var SimpleObservable = require("can-simple-observable");
 var canReflect = require("can-reflect");
 var domMutate = require('can-util/dom/mutate/mutate');
 var Construct = require("can-construct");
 var observe = require("can-observe");
+var tag = require('can-view-callbacks').tag;
 
 var innerHTML = function(el){
     return el && el.innerHTML;
@@ -539,5 +542,27 @@ helpers.makeTests("can-component viewModels", function(){
         QUnit.equal(vm.myChild.name,"inner", "got instance");
 
     });
+
+		QUnit.test("Can be called on an element using preventDataBindings (#183)", function(){
+			Component.extend({
+				tag: "prevent-data-bindings",
+				ViewModel: {},
+				view: stache("{{value}}")
+			});
+
+			var document = this.document;
+			var el = document.createElement("div");
+			var callback = tag("prevent-data-bindings");
+
+			var vm = new observe.Object({ value: "it worked" });
+			canData.set.call(el, "viewModel", vm);
+			canData.set.call(el, "preventDataBindings", true);
+			callback(el, {
+				scope: new Scope({ value: "it did not work" })
+			});
+			canData.set.call(el, "preventDataBindings", false);
+
+			QUnit.equal(el.firstChild.nodeValue, "it worked");
+		});
 
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,6 +29,7 @@ var helpers = {
 
 
     			if(doc) {
+						this.document = doc;
     				this.fixture = doc.createElement("div");
     				doc.body.appendChild(this.fixture);
     			} else {


### PR DESCRIPTION
This handles elements that do not set up bindings, by first trying to
get the viewModel from the element's data, but otherwise just guarding
against assuming that `viewModel` is defined.

Closes #183