### PR TITLE
Deprecate providing ViewModel as a plain object

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -180,6 +180,9 @@ var Component = Construct.extend(
 					if(typeof this.prototype.ViewModel === "function") {
 						this.ViewModel = this.prototype.ViewModel;
 					} else {
+						//!steal-remove-start
+						canLog.warn("can-component: " + this.prototype.tag + " is extending the default map type; please explicitly provide a constructor function");
+						//!steal-remove-end
 						this.ViewModel = types.DefaultMap.extend(vmName, this.prototype.ViewModel);
 					}
 				} else {

--- a/docs/ViewModel.md
+++ b/docs/ViewModel.md
@@ -100,27 +100,6 @@ var result = stache("Page {{page}}.")(newViewModel);
 element.innerHTML = result;
 ```
 
-There is a short-hand for the prototype methods and properties used to extend the
-[can-types.DefaultMap default Map type] (typically [can-define/map/map])
-by setting the Component’s ViewModel to an object and using
-that anonymous type as the view model.
-
-The following does the same as above:
-
-```js
-Component.extend({
-	tag: "my-paginate",
-	ViewModel: {
-		offset: {value: 0},
-		limit: {value: 20},
-		get page() {
-			return Math.floor(this.offset / this.limit) + 1;
-		}
-	},
-	view: stache("Page {{page}}.")
-})
-```
-
 ## Values passed from attributes
 
 Values can be "passed" into the viewModel instance of a component, similar to passing arguments into a function. Using

--- a/docs/component.md
+++ b/docs/component.md
@@ -383,7 +383,7 @@ The following tree combo lets people walk through a hierarchy and select locatio
 
 The secret to this widget is the viewModel’s `breadcrumb` property, which is an array
 of items the user has navigated through, and `selectableItems`, which represents the children of the
-last item in the breadcrub.  These are defined on the viewModel like:
+last item in the breadcrumb.  These are defined on the viewModel like:
 
 ```js
     breadcrumb: [],


### PR DESCRIPTION
This adds a warning when someone provides a plain object as the component’s ViewModel property.