### PR TITLE
Fix issue with can-slot not working with <self-closing/> components

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -349,7 +349,10 @@ var Component = Construct.extend(
 
 				// Add a hookup for each <can-slot>
 				options.tags['can-slot'] = makeInsertionTagCallback('can-slot', componentTagData, shadowTagData, leakScope, function(el) {
-					return componentTagData.templates[el.getAttribute("name")];
+					var templates = componentTagData.templates;
+					if (templates) {// This is undefined if the component is <self-closing/>
+						return templates[el.getAttribute("name")];
+					}
 				});
 
 				// Add a hookup for <content>

--- a/test/component-slot-test.js
+++ b/test/component-slot-test.js
@@ -153,6 +153,30 @@ test("<can-slot> Works with default content", function() {
 	equal(testView.firstChild.innerHTML, 'Default Content');
 });
 
+test("<can-slot> Works in a self-closing template", function() {
+	/* A component like <hello-world/> can be rendered like <hello-world></hello-world> */
+
+	var ViewModel = DefineMap.extend({});
+
+	Component.extend({
+		tag : 'my-email',
+		view : stache(
+			'<can-slot name="subject">' +
+				'Default Content' +
+			'</can-slot>'
+		),
+		ViewModel: ViewModel
+	});
+
+	var renderer = stache(
+		'<my-email/>'
+	);
+
+	var testView = renderer();
+
+	equal(testView.firstChild.innerHTML, 'Default Content');
+});
+
 test("<can-slot> Context one-way binding works", function() {
 	/*Passing in a custom context like <can-slot name='subject' {context}='value' />*/
 


### PR DESCRIPTION
This fixes an issue where a component that uses can-slot would throw an error if it was used as a self-closing tag in a template.

Part of https://github.com/canjs/can-stache/issues/418