### PR TITLE
Allow components to be instantiated with new

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -240,6 +240,11 @@ var Component = Construct.extend(
 			// If a view is not provided, we fall back to
 			// dynamic scoping regardless of settings.
 
+			// Create an element if it doesn’t exist and make it available outside of this
+			if (!el) {
+				el = document.createElement(this.tag);
+			}
+			this.element = el;
 
 			// an array of teardown stuff that should happen when the element is removed
 			var teardownFunctions = [];
@@ -251,6 +256,14 @@ var Component = Construct.extend(
 				};
 			var setupBindings = !domData.get.call(el, "preventDataBindings");
 			var viewModel, frag;
+
+			// Create componentTagData if it wasn’t provided
+			if (!componentTagData) {
+				componentTagData = {
+					// TODO: fill this out once we implement #233 (passing viewModel),
+					// #234 (passing templates), and #235 (passing <content />)
+				};
+			}
 
 			// ## Scope
 			var teardownBindings;

--- a/docs/component.md
+++ b/docs/component.md
@@ -89,9 +89,32 @@ a [can-component/can-template] that is used to render the search results:
    the [can-component/content] element.  The data accessible to the `LIGHT_DOM` can be controlled
    with [can-component.prototype.leakScope].
 
+@signature `new Component()`
+
+Create an instance of a component without rendering it in a template.
+
+The following defines a `MyGreeting` component and creates a `my-greeting`
+element by calling `new` on the component’s constructor function:
+
+```js
+const MyGreeting = Component.extend({
+  tag: "my-greeting",
+  view: "Hello {{subject}}",
+  ViewModel: {
+    subject: {
+      default: "world"
+    }
+  }
+});
+
+const myGreetingInstance = new MyGreeting();
+// myGreetingInstance.element is <my-greeting>Hello world</my-greeting>
+// myGreetingInstance.viewModel has {subject: "world"}
+```
+
+  @release 4.3
 
 @body
-
 
 ## Use
 

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -1,0 +1,27 @@
+var Component = require("can-component");
+var QUnit = require("steal-qunit");
+
+QUnit.module("can-component instantiation");
+
+QUnit.test("Components can be instantiated with new", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "new-instantiation",
+		view: "Hello {{message}}",
+		ViewModel: {
+			message: "string"
+		}
+	});
+
+	var componentInstance = new ComponentConstructor();
+	var element = componentInstance.element;
+	var viewModel = componentInstance.viewModel;
+
+	// Basics look correct
+	QUnit.ok(element, "instance has element property");
+	QUnit.equal(element.textContent, "Hello ", "element has correct text content");
+	QUnit.ok(viewModel, "instance has viewModel property");
+
+	// Updating the viewModel should update the element
+	viewModel.message = "world";
+	QUnit.equal(element.textContent, "Hello world", "element has correct text content after updating viewModel");
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,3 +7,4 @@ require("./component-events-test");
 require("./example-test");
 require('./component-slot-test');
 require('./component-define-test');
+require("./component-instantiation-test");


### PR DESCRIPTION
This makes it possible to call a component’s constructor function with no arguments to get a component instance back that has element and viewModel properties.

This does not cover accepting parameters such as templates or a viewModel; those will be covered in later issues: https://github.com/canjs/can-component/issues/233 https://github.com/canjs/can-component/issues/234 https://github.com/canjs/can-component/issues/235

Docs:
<img width="765" alt="screen shot 2018-04-03 at 4 25 33 pm" src="https://user-images.githubusercontent.com/10070176/38280800-1fa29e86-375c-11e8-93f5-24b52d9dcd89.png">

Closes https://github.com/canjs/can-component/issues/232