### PR TITLE
Add support for rendering components in stache templates

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -418,8 +418,7 @@ var Component = Construct.extend(
 			teardownFunctions.push(function() {
 				nodeLists.unregister(nodeList);
 			});
-
-
+			this.nodeList = nodeList;
 
 			frag = betweenTagsRenderer(betweenTagsTagData.scope, betweenTagsTagData.options, nodeList);
 
@@ -444,5 +443,12 @@ var Component = Construct.extend(
 			}
 		}
 	});
+
+// This adds support for components being rendered as values in stache templates
+var viewInsertSymbol = canSymbol.for("can.viewInsert");
+Component.prototype[viewInsertSymbol] = function(viewData) {
+	viewData.nodeList.newDeepChildren.push(this.nodeList);
+	return this.element;
+};
 
 module.exports = namespace.Component = Component;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "can-reflect": "^1.6.0",
     "can-simple-map": "^4.0.0",
     "can-simple-observable": "^2.0.0",
-    "can-stache": "^4.1.0",
+    "can-stache": "^4.4.0-pre.1",
     "can-stache-bindings": "^4.0.3",
     "can-stache-key": "^1.0.0",
     "can-symbol": "^1.4.1",

--- a/test/component-in-stache-test.js
+++ b/test/component-in-stache-test.js
@@ -1,0 +1,77 @@
+var Component = require("can-component");
+var SimpleMap = require("can-simple-map");
+var stache = require("can-stache");
+var canReflect = require("can-reflect");
+var QUnit = require("steal-qunit");
+
+var viewModel = require("can-view-model");
+var canDev = require("can-util/js/dev/dev");
+var testHelpers = require("can-test-helpers");
+
+QUnit.module("can-component can be rendered by can-stache");
+
+QUnit.test("basics work", function (assert) {
+	var ComponentConstructor = Component.extend({
+		tag: "component-in-stache",
+		view: "Hello {{message}}",
+		ViewModel: {
+			message: "string"
+		}
+	});
+
+	var componentInstance = new ComponentConstructor();
+
+	var fragment = stache("<div>{{{componentInstance}}}</div>")({
+		componentInstance: componentInstance
+	});
+	var viewModel = componentInstance.viewModel;
+
+	// Basics look correct
+	assert.equal(fragment.textContent, "Hello ", "fragment has correct text content");
+
+	// Updating the viewModel should update the element
+	viewModel.message = "world";
+	assert.equal(fragment.textContent, "Hello world", "fragment has correct text content after updating viewModel");
+});
+
+QUnit.test("wrapped in a conditional", function (assert) {
+	var done = assert.async();
+
+	var ComponentConstructor = Component.extend({
+		tag: "component-in-stache",
+		view: "Hello {{message}}",
+		ViewModel: {
+			message: "string"
+		}
+	});
+
+	var componentInstance = new ComponentConstructor();
+	var templateVM = new SimpleMap({
+		componentInstance: componentInstance,
+		showComponent: false
+	});
+	var componentVM = componentInstance.viewModel;
+
+	var fragment = stache("<div>{{#if(showComponent)}}{{{componentInstance}}}{{/if}}</div>")(templateVM);
+
+	// Template starts off empty
+	assert.equal(fragment.textContent, "", "fragment starts off without content");
+
+	// Show the component
+	templateVM.set("showComponent", true);
+	assert.equal(fragment.textContent, "Hello ", "fragment updates to include the component");
+
+	// Updating the componentVM should update the element
+	componentVM.message = "world";
+	assert.equal(fragment.textContent, "Hello world", "fragment has correct text content after updating componentVM");
+
+	// Listen for when the viewmodel is bound; need to make sure it isn’t at the end
+	canReflect.onInstanceBoundChange(ComponentConstructor.ViewModel, function(instance, isBound) {
+		assert.equal(isBound, false, "view model is no longer bound");
+		done();
+	});
+
+	// Hide the component
+	templateVM.set("showComponent", false);
+	assert.equal(fragment.textContent, "", "fragment ends without content");
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,3 +8,4 @@ require("./example-test");
 require('./component-slot-test');
 require('./component-define-test');
 require("./component-instantiation-test");
+require("./component-in-stache-test");


### PR DESCRIPTION
This adds the can.viewInsert symbol to each component instance so when a component is rendered as a value in a stache template, it can be correctly removed later.

The tests cover this specific functionality and the overall integration of changes made in can-view-live and can-stache to make this feature work.

Part of https://github.com/canjs/can-stache/issues/502