### PR TITLE
Allow components to be instantiated with templates

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -89,7 +89,7 @@ a [can-component/can-template] that is used to render the search results:
    the [can-component/content] element.  The data accessible to the `LIGHT_DOM` can be controlled
    with [can-component.prototype.leakScope].
 
-@signature `new Component()`
+@signature `new Component([options])`
 
 Create an instance of a component without rendering it in a template.
 
@@ -110,6 +110,41 @@ const MyGreeting = Component.extend({
 const myGreetingInstance = new MyGreeting();
 // myGreetingInstance.element is <my-greeting>Hello world</my-greeting>
 // myGreetingInstance.viewModel has {subject: "world"}
+```
+
+@param {Object} [options] Options for rendering the component, including `templates`.
+
+In the example below, a component that uses partials is defined and the partial is
+passed in when the component is instantiated.
+
+```js
+const TodosPage = Component.extend({
+  tag: "todos-page",
+  view: "<ul>{{#each(items)}} {{>item-partial}} {{/each}}</ul>",
+  ViewModel: {
+    items: {
+      default: ["eat", "sleep", "code"]
+    }
+  }
+});
+
+const todosPageInstance = new TodosPage({
+  template: {
+    "item-partial": "<li>{{name}}</li>"
+  }
+});
+```
+
+This would make `todosPageInstance.element` a fragment with the following structure:
+
+```html
+<todos-page>
+  <ul>
+    <li>eat</li>
+    <li>sleep</li>
+    <li>code</li>
+  </ul>
+</todos-page>
 ```
 
   @release 4.3

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -25,3 +25,31 @@ QUnit.test("Components can be instantiated with new", function() {
 	viewModel.message = "world";
 	QUnit.equal(element.textContent, "Hello world", "element has correct text content after updating viewModel");
 });
+
+QUnit.test("Components can be instantiated with templates", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "new-instantiation",
+		view: "Hello {{message}} {{>message-input}}",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var componentInstance = new ComponentConstructor({
+		templates: {
+			"message-input": "<input value:bind='message' />"
+		}
+	});
+
+	// Basics look correct
+	var element = componentInstance.element;
+	var inputElement = element.querySelector("input");
+	QUnit.ok(inputElement, "template rendered");
+	QUnit.equal(inputElement.value, "world", "input has correct value");
+
+	// Updating the viewModel should update the template
+	var viewModel = componentInstance.viewModel;
+	viewModel.message = "mundo";
+	QUnit.equal(element.textContent, "Hello mundo ", "element has correct text content after updating viewModel");
+	QUnit.equal(inputElement.value, "mundo", "input has correct value after updating viewModel");
+});


### PR DESCRIPTION
This makes it possible to instantiate a new component with new and pass it an object with partials to use for the main template.

Docs (these will be expanded to mention `content` and `viewModel` when I get to adding those):

<img width="940" alt="screen shot 2018-04-23 at 6 00 54 pm" src="https://user-images.githubusercontent.com/10070176/39160460-598a4896-4720-11e8-8276-0b8221e7e8f4.png">

Closes https://github.com/canjs/can-component/issues/234