### PR TITLE
Allow components to be instantiated with <content />

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -271,6 +271,10 @@ var Component = Construct.extend(
 			// ## Scope
 			var teardownBindings;
 			if (setupBindings) {
+				// Check for the component being instantiated with a scope
+				if (componentTagData.scope !== undefined && componentTagData.scope instanceof Scope === false) {
+					componentTagData.scope = new Scope(componentTagData.scope);
+				}
 				var setupFn = componentTagData.setupBindings ||
 					function(el, callback, data){
 						return stacheBindings.behaviors.viewModel(el, componentTagData,

--- a/can-component.js
+++ b/can-component.js
@@ -348,6 +348,18 @@ var Component = Construct.extend(
 
 			// ## Rendering
 
+			// Hook up any <content> with which the component was instantiated
+			var componentContent = componentTagData.content;
+			if (componentContent) {
+				// Check if it’s already a renderer function or
+				// a string that needs to be parsed by stache
+				if (typeof componentContent === "function") {
+					componentTagData.subtemplate = componentContent;
+				} else if (typeof componentContent === "string") {
+					componentTagData.subtemplate = stache(componentContent);
+				}
+			}
+
 			var leakScope = {
 				toLightContent: this.leakScope === true,
 				intoShadowContent: this.leakScope === true

--- a/can-component.js
+++ b/can-component.js
@@ -237,6 +237,10 @@ var Component = Construct.extend(
 		// When a new component instance is created, setup bindings, render the view, etc.
 		setup: function(el, componentTagData) {
 			var component = this;
+			var options = {
+				helpers: {},
+				tags: {}
+			};
 			// If a view is not provided, we fall back to
 			// dynamic scoping regardless of settings.
 
@@ -257,6 +261,42 @@ var Component = Construct.extend(
 			}
 			this.element = el;
 
+			// Hook up any <content> with which the component was instantiated
+			var componentContent = componentTagData.content;
+			if (componentContent !== undefined) {
+				// Check if it’s already a renderer function or
+				// a string that needs to be parsed by stache
+				if (typeof componentContent === "function") {
+					componentTagData.subtemplate = componentContent;
+				} else if (typeof componentContent === "string") {
+					componentTagData.subtemplate = stache(componentContent);
+				}
+			}
+
+			// Check for the component being instantiated with a scope
+			var componentScope = componentTagData.scope;
+			if (componentScope !== undefined && componentScope instanceof Scope === false) {
+				componentTagData.scope = new Scope(componentScope);
+			}
+
+			// Hook up any templates with which the component was instantiated
+			var componentTemplates = componentTagData.templates;
+			if (componentTemplates !== undefined) {
+				options.partials = {};
+				for (var name in componentTemplates) {
+					var template = componentTemplates[name];
+
+					// Check if it’s already a renderer function or
+					// a string that needs to be parsed by stache
+					if (typeof template === "function") {
+						options.partials[name] = template;
+					} else if (typeof template === "string") {
+						var debugName = string.capitalize( string.camelize(name) ) + "Template";
+						options.partials[name] = stache(debugName, template);
+					}
+				}
+			}
+
 			// an array of teardown stuff that should happen when the element is removed
 			var teardownFunctions = [];
 			var initialViewModelData = {};
@@ -271,10 +311,6 @@ var Component = Construct.extend(
 			// ## Scope
 			var teardownBindings;
 			if (setupBindings) {
-				// Check for the component being instantiated with a scope
-				if (componentTagData.scope !== undefined && componentTagData.scope instanceof Scope === false) {
-					componentTagData.scope = new Scope(componentTagData.scope);
-				}
 				var setupFn = componentTagData.setupBindings ||
 					function(el, callback, data){
 						return stacheBindings.behaviors.viewModel(el, componentTagData,
@@ -317,10 +353,7 @@ var Component = Construct.extend(
 			domData.set.call(el, "preventDataBindings", true);
 
 			// ## Helpers
-			var options = {
-					helpers: {},
-					tags: {}
-				};
+
 			// Setup helpers to callback with `this` as the component
 			if(this.helpers !== undefined) {
 				canReflect.eachKey(this.helpers, function(val, prop) {
@@ -351,18 +384,6 @@ var Component = Construct.extend(
 			}
 
 			// ## Rendering
-
-			// Hook up any <content> with which the component was instantiated
-			var componentContent = componentTagData.content;
-			if (componentContent) {
-				// Check if it’s already a renderer function or
-				// a string that needs to be parsed by stache
-				if (typeof componentContent === "function") {
-					componentTagData.subtemplate = componentContent;
-				} else if (typeof componentContent === "string") {
-					componentTagData.subtemplate = stache(componentContent);
-				}
-			}
 
 			var leakScope = {
 				toLightContent: this.leakScope === true,
@@ -404,23 +425,6 @@ var Component = Construct.extend(
 				options.tags.content = makeInsertionTagCallback('content',  componentTagData, shadowTagData, leakScope, function() {
 					return componentTagData.subtemplate;
 				});
-
-				// Hook up any templates with which the component was instantiated
-				if (componentTagData.templates) {
-					options.partials = {};
-					for (var name in componentTagData.templates) {
-						var template = componentTagData.templates[name];
-
-						// Check if it’s already a renderer function or
-						// a string that needs to be parsed by stache
-						if (typeof template === "function") {
-							options.partials[name] = template;
-						} else if (typeof template === "string") {
-							var debugName = string.capitalize( string.camelize(name) ) + "Template";
-							options.partials[name] = stache(debugName, template);
-						}
-					}
-				}
 
 				betweenTagsRenderer = this.constructor.renderer;
 				betweenTagsTagData = shadowTagData;

--- a/docs/component.md
+++ b/docs/component.md
@@ -113,9 +113,9 @@ const myGreetingInstance = new MyGreeting();
 ```
 
 @param {Object} [options] Options for rendering the component, including
-`content` and `templates`.
+`content`, `scope`, and `templates`.
 
-In the example below, the `content` option is used to pass `LIGHT_DOM` into a
+The `content` option is used to pass `LIGHT_DOM` into a
 component when it is instantiated.
 
 ```js
@@ -135,7 +135,29 @@ This would make `helloWorldInstance.element` a fragment with the following struc
 <hello-world>Hello <em>mundo</em></hello-world>
 ```
 
-In the example below, the `templates` option is used to pass a partial into a
+You can also provide a `scope` with which the content should be rendered:
+
+```js
+const HelloWorld = Component.extend({
+  tag: "hello-world",
+  view: "Hello <content>world</content>"
+});
+
+const helloWorldInstance = new HelloWorld({
+  content: "<em>{{message}}</em>",
+  scope: {
+    message: "mundo"
+  }
+});
+```
+
+This would make `helloWorldInstance.element` a fragment with the following structure:
+
+```html
+<hello-world>Hello <em>mundo</em></hello-world>
+```
+
+The `templates` option is used to pass a partial into a
 component when it is instantiated.
 
 ```js

--- a/docs/component.md
+++ b/docs/component.md
@@ -112,10 +112,31 @@ const myGreetingInstance = new MyGreeting();
 // myGreetingInstance.viewModel has {subject: "world"}
 ```
 
-@param {Object} [options] Options for rendering the component, including `templates`.
+@param {Object} [options] Options for rendering the component, including
+`content` and `templates`.
 
-In the example below, a component that uses partials is defined and the partial is
-passed in when the component is instantiated.
+In the example below, the `content` option is used to pass `LIGHT_DOM` into a
+component when it is instantiated.
+
+```js
+const HelloWorld = Component.extend({
+  tag: "hello-world",
+  view: "Hello <content>world</content>"
+});
+
+const helloWorldInstance = new HelloWorld({
+  content: "<em>mundo</em>"
+});
+```
+
+This would make `helloWorldInstance.element` a fragment with the following structure:
+
+```html
+<hello-world>Hello <em>mundo</em></hello-world>
+```
+
+In the example below, the `templates` option is used to pass a partial into a
+component when it is instantiated.
 
 ```js
 const TodosPage = Component.extend({

--- a/docs/component.md
+++ b/docs/component.md
@@ -123,13 +123,13 @@ const TodosPage = Component.extend({
   view: "<ul>{{#each(items)}} {{>item-partial}} {{/each}}</ul>",
   ViewModel: {
     items: {
-      default: ["eat", "sleep", "code"]
+      default: () => ["eat", "sleep", "code"]
     }
   }
 });
 
 const todosPageInstance = new TodosPage({
-  template: {
+  templates: {
     "item-partial": "<li>{{name}}</li>"
   }
 });

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -1,5 +1,6 @@
 var Component = require("can-component");
 var QUnit = require("steal-qunit");
+var stache = require("can-stache");
 
 QUnit.module("can-component instantiation");
 
@@ -26,9 +27,45 @@ QUnit.test("Components can be instantiated with new", function() {
 	QUnit.equal(element.textContent, "Hello world", "element has correct text content after updating viewModel");
 });
 
+QUnit.test("Components can be instantiated with <content> - string", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "new-instantiation-content",
+		view: "Hello <content>{{message}}</content>",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var componentInstance = new ComponentConstructor({
+		content: "<em>mundo</em>"
+	});
+
+	// Basics look correct
+	var element = componentInstance.element;
+	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content rendered");
+});
+
+QUnit.test("Components can be instantiated with <content> - renderer function", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "new-instantiation-content",
+		view: "Hello <content>{{message}}</content>",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var componentInstance = new ComponentConstructor({
+		content: stache("<em>mundo</em>")
+	});
+
+	// Basics look correct
+	var element = componentInstance.element;
+	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content rendered");
+});
+
 QUnit.test("Components can be instantiated with templates", function() {
 	var ComponentConstructor = Component.extend({
-		tag: "new-instantiation",
+		tag: "new-instantiation-templates",
 		view: "Hello {{message}} {{>message-input}}",
 		ViewModel: {
 			message: {default: "world"}

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -1,4 +1,5 @@
 var Component = require("can-component");
+var DefineMap = require("can-define/map/map");
 var QUnit = require("steal-qunit");
 var stache = require("can-stache");
 
@@ -27,27 +28,9 @@ QUnit.test("Components can be instantiated with new", function() {
 	QUnit.equal(element.textContent, "Hello world", "element has correct text content after updating viewModel");
 });
 
-QUnit.test("Components can be instantiated with <content> - string", function() {
+QUnit.test("Components can be instantiated with <content> - no scope", function() {
 	var ComponentConstructor = Component.extend({
-		tag: "new-instantiation-content",
-		view: "Hello <content>{{message}}</content>",
-		ViewModel: {
-			message: {default: "world"}
-		}
-	});
-
-	var componentInstance = new ComponentConstructor({
-		content: "<em>mundo</em>"
-	});
-
-	// Basics look correct
-	var element = componentInstance.element;
-	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content rendered");
-});
-
-QUnit.test("Components can be instantiated with <content> - renderer function", function() {
-	var ComponentConstructor = Component.extend({
-		tag: "new-instantiation-content",
+		tag: "new-instantiation-content-no-scope",
 		view: "Hello <content>{{message}}</content>",
 		ViewModel: {
 			message: {default: "world"}
@@ -57,10 +40,79 @@ QUnit.test("Components can be instantiated with <content> - renderer function", 
 	var componentInstance = new ComponentConstructor({
 		content: stache("<em>mundo</em>")
 	});
+	var element = componentInstance.element;
 
 	// Basics look correct
+	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content is rendered");
+});
+
+QUnit.test("Components can be instantiated with <content> - with plain content and scope", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "new-instantiation-plain-content-and-scope",
+		view: "Hello <content>{{message}}</content>",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var componentInstance = new ComponentConstructor({
+		content: "<em>{{message}}</em>",
+		scope: {
+			message: "mundo"
+		}
+	});
 	var element = componentInstance.element;
-	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content rendered");
+
+	// Basics look correct
+	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content is rendered");
+});
+
+QUnit.test("Components can be instantiated with <content> - with scope - leakScope false", function() {
+	var ComponentConstructor = Component.extend({
+		leakScope: false,
+		tag: "new-instantiation-content-leakscope-false",
+		view: "Hello <content>{{message}}</content>",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var scopeVM = new DefineMap({});
+	var componentInstance = new ComponentConstructor({
+		content: "<em>{{message}}</em>",
+		scope: scopeVM
+	});
+	var element = componentInstance.element;
+
+	// Start off without the key defined in the scope; with leakScope false,
+	// no message will be rendered
+	QUnit.equal(element.innerHTML, "Hello <em></em>", "content is rendered with the provided scope");
+
+	// Set the key in the scope; now a message will be rendered
+	scopeVM.set("message", "mundo");
+	QUnit.equal(element.innerHTML, "Hello <em>mundo</em>", "content updates with the provided scope");
+});
+
+QUnit.test("Components can be instantiated with <content> - with scope - leakScope true", function() {
+	var ComponentConstructor = Component.extend({
+		leakScope: true,
+		tag: "new-instantiation-content-leakscope-true",
+		view: "Hello <content>{{message}}</content>",
+		ViewModel: {
+			message: {default: "world"}
+		}
+	});
+
+	var componentInstance = new ComponentConstructor({
+		content: "<em>{{scope.find('message')}}</em>",
+		scope: {
+			message: "mundo"
+		}
+	});
+	var element = componentInstance.element;
+
+	// leakScope works
+	QUnit.equal(element.innerHTML, "Hello <em>world</em>", "content is rendered with the component’s scope");
 });
 
 QUnit.test("Components can be instantiated with templates", function() {


### PR DESCRIPTION
This makes it possible to instantiate a new component with an options object with `content` and `scope` properties, which have a similar effect to rendering the component with content in a stache template.

<img width="902" alt="screen shot 2018-05-01 at 1 23 30 pm" src="https://user-images.githubusercontent.com/10070176/39492167-9a516d2c-4d43-11e8-80f5-82e600ceec33.png">

Closes https://github.com/canjs/can-component/issues/235