### PR TITLE
Update docs to show 4.x syntax

### DIFF
--- a/docs/ViewModel.md
+++ b/docs/ViewModel.md
@@ -7,14 +7,17 @@ Provides or describes a constructor function that provides values and methods
 to the component’s [can-component::view view]. The constructor function
 is initialized with values specified by the component element’s [can-stache-bindings data bindings].
 
-@option {function} A constructor function usually defined by [can-define/map/map.extend DefineMap.extend] or
+@option {function} A constructor function (usually defined by [can-define/map/map.extend DefineMap.extend] or
 [can-map Map.extend] that will be used to create a new observable instance accessible by
-the component’s [can-component::view].
+the component’s [can-component::view]) or an Object that will be passed to [can-define/map/map.extend DefineMap.extend].
 
 For example, every time `<my-tag>` is found, a new instance of `MyTagViewModel` will
 be created:
 
 ```js
+import Component from "can-component";
+import DefineMap from "can-define/map/map";
+
 const MyTagViewModel = DefineMap.extend( "MyTagViewModel", {
 	message: "string"
 } );
@@ -22,7 +25,21 @@ const MyTagViewModel = DefineMap.extend( "MyTagViewModel", {
 Component.extend( {
 	tag: "my-tag",
 	ViewModel: MyTagViewModel,
-	view: stache( "<h1>{{message}}</h1>" )
+	view: "<h1>{{message}}</h1>"
+} );
+```
+
+The example above can be abbreviated to:
+
+```js
+import Component from "can-component";
+
+Component.extend( {
+	tag: "my-tag",
+	ViewModel: {
+		message: "string"
+	},
+	view: "<h1>{{message}}</h1>"
 } );
 ```
 
@@ -53,8 +70,8 @@ component shows the current page number based off a `limit` and `offset` value:
 
 ```js
 const MyPaginateViewModel = DefineMap.extend( {
-	offset: { value: 0 },
-	limit: { value: 20 },
+	offset: { default: 0 },
+	limit: { default: 20 },
 	get page() {
 		return Math.floor( this.offset / this.limit ) + 1;
 	}
@@ -63,7 +80,7 @@ const MyPaginateViewModel = DefineMap.extend( {
 Component.extend( {
 	tag: "my-paginate",
 	ViewModel: MyPaginateViewModel,
-	view: stache( "Page {{page}}." )
+	view: "Page {{page}}."
 } );
 ```
 
@@ -110,13 +127,13 @@ The following does the same as above:
 Component.extend( {
 	tag: "my-paginate",
 	ViewModel: {
-		offset: { value: 0 },
-		limit: { value: 20 },
+		offset: { default: 0 },
+		limit: { default: 20 },
 		get page() {
 			return Math.floor( this.offset / this.limit ) + 1;
 		}
 	},
-	view: stache( "Page {{page}}." )
+	view: "Page {{page}}."
 } );
 ```
 
@@ -143,13 +160,13 @@ The following component requires an `offset` and `limit`:
 Component.extend( {
 	tag: "my-paginate",
 	ViewModel: {
-		offset: { value: 0 },
-		limit: { value: 20 },
+		offset: { default: 0 },
+		limit: { default: 20 },
 		get page() {
 			return Math.floor( this.offset / this.limit ) + 1;
 		}
 	},
-	view: stache( "Page {{page}}." )
+	view: "Page {{page}}."
 } );
 ```
 
@@ -218,21 +235,19 @@ from a view. For example, we can make `<my-paginate>` elements include a next
 button that calls the ViewModel’s `next` method like:
 
 ```js
-const ViewModel = DefineMap.extend( {
-	offset: { value: 0 },
-	limit: { value: 20 },
-	next: function() {
-		this.offset = this.offset + this.limit;
-	},
-	get page() {
-		return Math.floor( this.offset / this.limit ) + 1;
-	}
-} );
-
 Component.extend( {
 	tag: "my-paginate",
-	ViewModel: ViewModel,
-	view: stache( "Page {{page}} <button on:click='next()'>Next</button>" )
+	ViewModel: {
+		offset: { default: 0 },
+		limit: { default: 20 },
+		next: function() {
+			this.offset = this.offset + this.limit;
+		},
+		get page() {
+			return Math.floor( this.offset / this.limit ) + 1;
+		}
+	},
+	view: "Page {{page}} <button on:click='next()'>Next</button>"
 } );
 ```
 
@@ -248,7 +263,7 @@ dispatches a `"close"` event when its close method is called:
 ```js
 Component.extend( {
 	tag: "player-edit",
-	view: stache( $( "#player-edit-stache" ).html() ),
+	view: document.getElementById( "player-edit-stache" ).innerHTML,
 	ViewModel: DefineMap.extend( {
 		player: Player,
 		close: function() {

--- a/docs/beforeremove.md
+++ b/docs/beforeremove.md
@@ -5,7 +5,7 @@ An event called only on component’s elements before they are removed from the
 document if live binding is performing the removal. It can be listened to
 within a component’s [can-component.prototype.events] object or on a component
 element with [can-stache-bindings.event] bindings.  This is an additional
-special event only on component elements. Checkout [can-dom-mutate//events/events]
+special event only on component elements. Check out [can-dom-mutate//events/events]
 for other mutation events.
 
 @signature `"{element} beforeremove": function(element, event)`
@@ -17,20 +17,24 @@ For example, the following might remove the component’s ViewModel
 from a parent component’s ViewModel:
 
 ```js
-{
+import canViewModel from "can-view-model";
+import Component from "can-component";
+
+Component.extend({
+	tag: "my-component",
 	events: {
 		"{element} beforeremove": function() {
 			canViewModel( this.element.parentNode )
 				.removePanel( this.viewModel );
 		}
 	}
-}
+});
 ```
 
-  @param {HTMLElement} element The component element.
-  @param {Event} event The `beforeremove` event object.
+	@param {HTMLElement} element The component element.
+	@param {Event} event The `beforeremove` event object.
 
-@signature `($beforeremove)="CALL_EXRESSION"`
+@signature `on:beforeremove="CALL_EXRESSION"`
 
 Uses [can-stache-bindings.event] bindings to listen for a component’s
 `beforeremove` event.
@@ -39,4 +43,4 @@ Uses [can-stache-bindings.event] bindings to listen for a component’s
 <my-panel on:beforeremove="removePanel(scope.viewModel)"/>
 ```
 
-  @param {can-stache/expressions/call} CALL_EXRESSION A call expression that calls some method when the event happens.
+	@param {can-stache/expressions/call} CALL_EXRESSION A call expression that calls some method when the event happens.

--- a/docs/can-slot.md
+++ b/docs/can-slot.md
@@ -10,20 +10,23 @@ of the `<can-template />` element from the `LIGHT_DOM` that has a matching [TEMP
 the `LIGHT_DOM` by default.
 
 ```js
+import Component from "can-component";
+import stache from "can-stache";
+
 Component.extend( {
 	tag: "my-email",
-	view: stache(
-		"<can-slot name=\"subject\" />"
-	)
+	view: `
+		<can-slot name="subject" />
+	`
 } );
 
-const renderer = stache(
-	"<my-email>" +
-    "<can-template name=\"subject\">" +
-      "{{subject}}" +
-    "</can-template>" +
-  "</my-email>"
-);
+const renderer = stache(`
+	<my-email>
+		<can-template name="subject">
+			{{subject}}
+		</can-template>
+	</my-email>
+`);
 
 renderer( {
 	subject: "Hello World"
@@ -59,25 +62,28 @@ Any `<can-slot>` that has a name attribute matching the name attribute of a `<ca
 replaced by the rendered inner contents of the <can-template>.
 
 ```js
+import Component from "can-component";
+import stache from "can-stache";
+
 Component.extend( {
 	tag: "my-email",
-	view: stache(
-		"<can-slot name=\"subject\" />" +
-    "<p>My Email</p>" +
-    "<can-slot name=\"body\" />"
-	)
+	view: `
+		<can-slot name="subject" />
+		<p>My Email</p>
+		<can-slot name="body" />
+	`
 } );
 
-const renderer = stache(
-	"<my-email>" +
-    "<can-template name=\"subject\">" +
-      "<h1>{{subject}}</h1>" +
-    "</can-template>" +
-    "<can-template name=\"body\">" +
-      "<span>{{body}}</span>" +
-    "</can-template>" +
-  "</my-email>"
-);
+const renderer = stache(`
+	<my-email>
+		<can-template name="subject">
+			<h1>{{subject}}</h1>
+		</can-template>
+		<can-template name="body">
+			<span>{{body}}</span>
+		</can-template>
+	</my-email>
+`);
 
 renderer( {
 	subject: "Hello World",
@@ -86,9 +92,9 @@ renderer( {
 
 /*
 <my-email>
-  <h1>Hello World</h1>
-  <p>My Email</p>
-  <span>The email body</span>
+	<h1>Hello World</h1>
+	<p>My Email</p>
+	<span>The email body</span>
 </my-email>
 */
 ```
@@ -100,34 +106,35 @@ passes `<my-email>`'s `subject` and `body` to the `subject` and `body` templates
 how `subject` and `body` are read by `{{this}}`.
 
 ```js
-const ViewModel = DefineMap.extend( {
-	subject: {
-		value: "Hello World"
-	},
-	body: {
-		value: "Later Gator"
-	}
-} );
+import Component from "can-component";
+import stache from "can-stache";
 
 Component.extend( {
 	tag: "my-email",
-	view: stache(
-		"<can-slot name=\"subject\" this:from=\"subject\"/>" +
-    "<can-slot name=\"body\" this:from=\"body\"/>"
-	),
-	ViewModel
+	view: `
+		<can-slot name="subject" this:from="subject" />
+		<can-slot name="body" this:from="body" />
+	`,
+	ViewModel: {
+		subject: {
+			default: "Hello World"
+		},
+		body: {
+			default: "Later Gator"
+		}
+	}
 } );
 
-const renderer = stache(
-	"<my-email>" +
-    "<can-template name=\"subject\">" +
-      "<h1>{{this}}</h1>" +
-    "</can-template>" +
-    "<can-template name=\"body\">" +
-      "<p>{{this}}</p>" +
-    "</can-template>" +
-  "</my-email>"
-);
+const renderer = stache(`
+	<my-email>
+		<can-template name="subject">
+			<h1>{{this}}</h1>
+		</can-template>
+		<can-template name="body">
+			<span>{{this}}</span>
+		</can-template>
+	</my-email>
+`);
 
 const testView = renderer( {
 	subject: "Hello World",
@@ -136,8 +143,8 @@ const testView = renderer( {
 
 /*
 <my-email>
-  <h1>Hello World</h1>
-  <p>This is a greeting.</p>
+	<h1>Hello World</h1>
+	<p>This is a greeting.</p>
 </my-email>
 */
 ```
@@ -148,20 +155,23 @@ Default content can be specified to be used if there is no matching `<can-templa
 or the matching `<can-template>` has no inner content.
 
 ```js
+import Component from "can-component";
+import stache from "can-stache";
+
 Component.extend( {
 	tag: "my-email",
-	view: stache(
-		"<can-slot name=\"subject\">" +
-      "<p>This is the default {{subject}}</p>" +
-    "</can-slot>"
-	)
+	view: `
+		<can-slot name="subject">
+			<p>This is the default {{subject}}</p>
+		</can-slot>
+	`
 } );
 
-const renderer = stache(
-	"<my-email>" +
-    "<can-template name=\"subject\" />" +
-  "</my-email>"
-);
+const renderer = stache(`
+	<my-email>
+		<can-template name="subject" />
+	</my-email>
+`);
 
 const testView = renderer( {
 	subject: "content"
@@ -169,7 +179,7 @@ const testView = renderer( {
 
 /*
 <my-email>
-  <p>This is the default content</p>
+	<p>This is the default content</p>
 </my-email>
 */
 ```

--- a/docs/can-template.md
+++ b/docs/can-template.md
@@ -15,20 +15,25 @@ For example, the following passes a `<my-modal>` component a `<can-template>`
 of the modal content:
 
 ```js
+import Component from "can-component";
+import stache from "can-stache";
+
 Component.extend( {
 	tag: "my-modal",
-	view: stache(
-		"<div class=\"wrapper\"><can-slot name=\"modal-content\" /></div>"
-	)
+	view: `
+		<div class="wrapper">
+			<can-slot name="modal-content" />
+		</div>
+	`
 } );
 
-const renderer = stache(
-	"<my-modal>" +
-    "<can-template name=\"modal-content\">" +
-      "Hello World!" +
-    "</can-template>" +
-  "</my-modal>"
-);
+const renderer = stache(`
+	<my-modal>
+		<can-template name="modal-content">
+			Hello World!
+		</can-template>
+	</my-modal>
+`);
 
 renderer(); //-> <my-modal><div class="wrapper">Hello World!</div></my-modal>
 ```
@@ -51,25 +56,28 @@ Any `<can-template>` that has a name attribute matching the name attribute of a 
 have it's inner contents rendered and replace the `<can-slot>`.
 
 ```js
+import Component from "can-component";
+import stache from "can-stache";
+
 Component.extend( {
 	tag: "my-email",
-	view: stache(
-		"<can-slot name=\"subject\" />" +
-    "<p>My Email</p>" +
-    "<can-slot name=\"body\" />"
-	)
+	view: `
+		<can-slot name="subject" />
+		<p>My Email</p>
+		<can-slot name="body" />
+	`
 } );
 
-const renderer = stache(
-	"<my-email>" +
-    "<can-template name=\"subject\">" +
-      "<h1>{{subject}}</h1>" +
-    "</can-template>" +
-    "<can-template name=\"body\">" +
-      "<span>{{body}}</span>" +
-    "</can-template>" +
-  "</my-email>"
-);
+const renderer = stache(`
+	<my-email>
+		<can-template name="subject">
+			<h1>{{subject}}</h1>
+		</can-template>
+		<can-template name="body">
+			<span>{{body}}</span>
+		</can-template>
+	</my-email>
+`);
 
 renderer( {
 	subject: "Hello World",
@@ -78,9 +86,9 @@ renderer( {
 
 /*
 <my-email>
-  <h1>Hello World</h1>
-  <p>My Email</p>
-  <span>The email body</span>
+	<h1>Hello World</h1>
+	<p>My Email</p>
+	<span>The email body</span>
 </my-email>
 */
 ```

--- a/docs/component.md
+++ b/docs/component.md
@@ -20,74 +20,62 @@ or application logic.
 Create an instance of a component on a particular tag in a [can-stache] view.
 Use the [can-stache-bindings bindings] syntaxes to set up bindings.
 
-The following creates a `my-autocomplete` element and passes the `my-autocomplete`'s
+The following creates a `my-autocomplete` element and passes the `my-autocomplete`’s
 [can-component.prototype.ViewModel] the `Search` model as its `source` property and
 a [can-component/can-template] that is used to render the search results:
 
 ```html
 <my-autocomplete source:from="Search">
-  <can-template name="search-results">
-    <li>{{name}}</li>
-  </can-template>
+	<can-template name="search-results">
+		<li>{{name}}</li>
+	</can-template>
 </my-autocomplete>
 ```
 
-  @release 2.3
+	@release 2.3
 
-  @param {String} TAG An HTML tag name that matches the [can-component::tag tag]
-  property of the component. Tag names should include a hyphen (`-`) or a colon (`:`) like:
-  `acme-tabs` or `acme:tabs`.
+	@param {String} TAG An HTML tag name that matches the [can-component::tag tag]
+	property of the component. Tag names should include a hyphen (`-`) or a colon (`:`) like:
+	`acme-tabs` or `acme:tabs`.
 
-  @param {can-stache-bindings} [BINDINGS] Use the following binding syntaxes
-  to connect the component’s [can-component::ViewModel] to the view's [can-view-scope scope]:
+	@param {can-stache-bindings} [BINDINGS] Use the following binding syntaxes
+	to connect the component’s [can-component::ViewModel] to the view’s [can-view-scope scope]:
 
-   - [can-stache-bindings.toChild]=[can-stache.expressions expression] — one-way data binding to child
-   - [can-stache-bindings.toParent]=[can-stache.expressions expression] — one-way data binding to parent
-   - [can-stache-bindings.twoWay]=[can-stache.expressions expression] — two-way data binding child to parent
-   - [can-stache-bindings.event]=[can-stache/expressions/call expression] — event binding on the view model
+	 - [can-stache-bindings.toChild]=[can-stache.expressions expression] — one-way data binding to child
+	 - [can-stache-bindings.toParent]=[can-stache.expressions expression] — one-way data binding to parent
+	 - [can-stache-bindings.twoWay]=[can-stache.expressions expression] — two-way data binding child to parent
+	 - [can-stache-bindings.event]=[can-stache/expressions/call expression] — event binding on the view model
 
-   Note that because DOM attribute names are case-insensitive, use hyphens (`-`)
-   in the attribute name to setup for `camelCase` properties.
+	 @param {can-stache.sectionRenderer} [TEMPLATES] Between the starting and ending tag
+	 can exist one or many [can-component/can-template] elements.  Use [can-component/can-template] elements
+	 to pass custom templates to child components.  Each `<can-template>`
+	 is given a `name` attribute and can be rendered by a corresponding [can-component/can-slot]
+	 in the component’s [can-component.prototype.view].
 
-   Example:
+	 For example, the following passes how each search result should look and an error message if
+	 the source is unable to request data:
 
-   ```html
-   <my-tag getChild:from="expression"
-           setParent:to="expression"
-           twoWay:bind="expression"
-           on:event="callExpression()"></my-tag>
-   ```
+	 ```html
+	 <my-autocomplete source:from="Search">
+		 <can-template name="search-results">
+			 <li>{{name}}</li>
+		 </can-template>
+		 <can-template name="search-error">
+			 <div class="error">{{message}}</div>
+		 </can-template>
+	 </my-autocomplete>
+	 ```
 
-   @param {can-stache.sectionRenderer} [TEMPLATES] Between the starting and ending tag
-   can exist one or many [can-component/can-template] elements.  Use [can-component/can-template] elements
-   to pass custom templates to child components.  Each `<can-template>`
-   is given a `name` attribute and can be rendered by a corresponding [can-component/can-slot]
-   in the component's [can-component.prototype.view].
+	 @param {can-stache.sectionRenderer} [LIGHT_DOM] The content between the starting and ending
+	 tag. For example, `Hello <b>World</b>` is the `LIGHT_DOM` in the following:
 
-   For example, the following passes how each search result should look and an error message if
-   the source is unable to request data:
+	 ```html
+	 <my-tag>Hello <b>World</b></my-tag>
+	 ```
 
-   ```html
-   <my-autocomplete source:from="Search">
-     <can-template name="search-results">
-       <li>{{name}}</li>
-     </can-template>
-     <can-template name="search-error">
-       <div class='error'>{{message}}</div>
-     </can-template>
-   </my-autocomplete>
-   ```
-
-   @param {can-stache.sectionRenderer} [LIGHT_DOM] The content between the starting and ending
-   tag. For example, `Hello <b>World</b>` is the `LIGHT_DOM` in the following:
-
-   ```html
-   <my-tag>Hello <b>World</b></my-tag>
-   ```
-
-   The `LIGHT_DOM` can be positioned with a component’s [can-component.prototype.view] with
-   the [can-component/content] element.  The data accessible to the `LIGHT_DOM` can be controlled
-   with [can-component.prototype.leakScope].
+	 The `LIGHT_DOM` can be positioned with a component’s [can-component.prototype.view] with
+	 the [can-component/content] element.  The data accessible to the `LIGHT_DOM` can be controlled
+	 with [can-component.prototype.leakScope].
 
 
 @body
@@ -100,18 +88,14 @@ with the methods and properties of how your component behaves:
 
 ```js
 import Component from "can-component";
-import DefineMap from "can-define/map/map";
-import stache from "can-stache";
-
-const HelloWorldVM = DefineMap.extend( {
-	visible: { value: false },
-	message: { value: "Hello There!" }
-} );
 
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "{{#if visible}}{{message}}{{else}}Click me{{/if}}" ),
-	ViewModel: HelloWorldVM,
+	view: "{{#if visible}}{{message}}{{else}}Click me{{/if}}",
+	ViewModel: {
+		visible: { default: false },
+		message: { default: "Hello There!" }
+	},
 	events: {
 		click: function() {
 			this.viewModel.visible = !this.viewModel.visible;
@@ -126,6 +110,8 @@ add `<hello-world/>` to a [can-stache] view, render
 the view, and insert the result in the page like:
 
 ```js
+import stache from "can-stache";
+
 const renderer = stache( "<hello-world/>" );
 document.body.appendChild( renderer( { } ) );
 ```
@@ -136,17 +122,17 @@ Check this out here:
 
 
 Typically, you do not append a single component at a time.  Instead,
-you'll render a view with many custom tags like:
+you’ll render a view with many custom tags like:
 
 ```html
 <srchr-app>
-  <srchr-search models:from="models">
-    <input name="search"/>
-  </srchr-search>
-  <ui-panel>
-    <srchr-history/>
-    <srchr-results models:from="models"/>
-  </ui-panel>
+	<srchr-search models:from="models">
+		<input name="search"/>
+	</srchr-search>
+	<ui-panel>
+		<srchr-history/>
+		<srchr-results models:from="models"/>
+	</ui-panel>
 </srchr-app>
 ```
 
@@ -186,7 +172,7 @@ The following component:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "<h1>Hello World</h1>" )
+	view: "<h1>Hello World</h1>"
 } );
 ```
 
@@ -203,7 +189,7 @@ The following component:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "<h1><content/></h1>" )
+	view: "<h1><content/></h1>"
 } );
 ```
 
@@ -226,7 +212,7 @@ The following component:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "<h1>{{message}}</h1>" )
+	view: "<h1>{{message}}</h1>"
 } );
 ```
 
@@ -250,7 +236,7 @@ Default values can be provided. The following component:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "<h1>{{message}}</h1>" ),
+	view: "<h1>{{message}}</h1>",
 	viewModel: {
 		message: "Hi"
 	}
@@ -309,7 +295,11 @@ const Person = DefineMap.extend( {
 
 The [can-component/connectedCallback] function may return a `disconnectedCallback` function this is called during teardown. Defined in the same closure scope as setup, its primary use is to tear down anything that was set up during the `connectedCallback` lifecycle hook.
 
-Special bindings are used to set up observable property behaviors that are unable to be represented easily within the declarative APIs of the `viewModel`. It doesn't remove all imperative code but will help keep imperitive code isolated and leave other properies more testable. Otherwise, properties like `name` in the example above, would need side-effects in setters or getters:
+Special bindings are used to set up observable property behaviors that are
+unable to be represented easily within the declarative APIs of the `viewModel`.
+It doesn’t remove all imperative code but will help keep imperative code
+isolated and leave other properties more testable. Otherwise, properties like
+`name` in the example above, would need side-effects in setters or getters:
 
 ```js
 const Person = DefineMap.extend( {
@@ -351,7 +341,7 @@ Component.extend( {
 } );
 ```
 
-Use [can-component/connectedCallback] to listen to when an component's element
+Use [can-component/connectedCallback] to listen to when an component’s element
 is inserted or removed from the DOM.
 
 
@@ -364,9 +354,11 @@ only renders friendly messages:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "{{#isFriendly message}}" +
-              "<h1>{{message}}</h1>" +
-            "{{/isFriendly}}" ),
+	view: `
+		{{#isFriendly message}}
+			<h1>{{message}}</h1>
+		{{/isFriendly}}
+	`
 	helpers: {
 		isFriendly: function( message, options ) {
 			if ( /hi|hello|howdy/.test( message ) ) {
@@ -398,9 +390,9 @@ elements like:
 
 ```html
 <my-tabs>
-  {{#each(foodTypes)}}
-    <my-panel title:from='title'>{{content}}</my-panel>
-  {{/each}}
+	{{#each(foodTypes)}}
+		<my-panel title:from="title">{{content}}</my-panel>
+	{{/each}}
 </my-tabs>
 ```
 
@@ -414,7 +406,7 @@ foodTypes.push( {
 ```
 
 The secret is that the `<my-panel>` element listens to when it is inserted
-and adds its data to the tabs' list of panels with:
+and adds its data to the tabs’ list of panels with:
 
 ```js
 const vm = this.parentViewModel = canViewModel( this.element.parentNode );
@@ -432,7 +424,7 @@ of items the user has navigated through, and `selectableItems`, which represents
 last item in the breadcrumb.  These are defined on the viewModel like:
 
 ```js
-Component.extend( {
+DefineMap.extend( {
 	breadcrumb: {
 		Value: DefineList
 	},
@@ -440,10 +432,10 @@ Component.extend( {
 		get: function() {
 			const breadcrumb = this.breadcrumb;
 
-			// if there's an item in the breadcrumb
+			// if there’s an item in the breadcrumb
 			if ( breadcrumb.length ) {
 
-				// return the last item's children
+				// return the last item’s children
 				const i = breadcrumb.length - 1;
 				return breadcrumb[ i ].children;
 			} else {
@@ -460,7 +452,7 @@ When the “+” icon is clicked next to each item, the viewModel’s `showChild
 adds that item to the breadcrumb like:
 
 ```js
-Component.extend( {
+DefineMap.extend( {
 	showChildren: function( item, ev ) {
 		ev.stopPropagation();
 		this.breadcrumb.push( item );
@@ -500,7 +492,7 @@ const AppViewModel = DefineMap.extend( {
 		return this.stopListening.bind( this );
 	},
 	paginate: {
-		value: function() {
+		default: function() {
 			return new Paginate( {
 				limit: 5
 			} );
@@ -529,15 +521,15 @@ its sub-components:
 
 ```html
 <my-app>
-  <my-grid promiseData:from='websitesPromise'>
-    {{#each(items)}}
-      <tr>
-        <td width='40%'>{{name}}</td>
-        <td width='70%'>{{url}}</td>
-      </tr>
-    {{/each}}
-  </my-grid>
-  <next-prev paginate:from='paginate'></next-prev>
-  <page-count page:from='paginate.page' count:from='paginate.pageCount'></page-count>
+	<my-grid promiseData:from="websitesPromise">
+		{{#each(items)}}
+			<tr>
+				<td width="40%">{{name}}</td>
+				<td width="70%">{{url}}</td>
+			</tr>
+		{{/each}}
+	</my-grid>
+	<next-prev paginate:from="paginate"></next-prev>
+	<page-count page:from="paginate.page" count:from="paginate.pageCount"></page-count>
 </my-app>
 ```

--- a/docs/connectedCallback.md
+++ b/docs/connectedCallback.md
@@ -27,4 +27,4 @@ const Person = DefineMap.extend( {
 
 `connectedCallback` is named as such to match the [web components](https://developers.google.com/web/fundamentals/web-components/customelements#reactions) spec for the same concept.
 
-  @return {Function|undefined} The `disconnectedCallback` function to be called during teardown. Defined in the same closure scope as setup, it's used to tear down anything that was set up during the `connectedCallback` lifecycle hook.
+	@return {Function|undefined} The `disconnectedCallback` function to be called during teardown. Defined in the same closure scope as setup, it's used to tear down anything that was set up during the `connectedCallback` lifecycle hook.

--- a/docs/content.md
+++ b/docs/content.md
@@ -16,20 +16,22 @@ The `<content>` tag can be used within `my-tag` to position the `LIGHT_DOM`.  Fo
 example, to position the `LIGHT_DOM` within an `<h1>`, `<my-tag>` could be defined like:
 
 ```js
+import Component from "can-component";
+
 Component.extend( {
 	tag: "my-tag",
-	view: stache( "<h1><content/></h1>" )
+	view: "<h1><content/></h1>"
 } );
 ```
 
-   @param {can-stache.sectionRenderer} [DEFAULT_CONTENT] The content that should be
-   used if there is no `LIGHT_DOM` passed to the component.
+	 @param {can-stache.sectionRenderer} [DEFAULT_CONTENT] The content that should be
+	 used if there is no `LIGHT_DOM` passed to the component.
 
-   The following, makes `my-tag` show `Hi There!` if no `LIGHT_DOM` is passed:
+	 The following, makes `my-tag` show `Hi There!` if no `LIGHT_DOM` is passed:
 
-   ```js
+	 ```js
 Component.extend( {
 	tag: "my-tag",
-	view: stache( "<h1><content>Hi There!</content></h1>" )
+	view: "<h1><content>Hi There!</content></h1>"
 } );
 ```

--- a/docs/events.md
+++ b/docs/events.md
@@ -7,6 +7,8 @@ Listen to events on elements and observables.
 that handle the event. For example:
 
 ```js
+import Component from "can-component";
+
 Component.extend( {
 	ViewModel: {
 		limit: "number",
@@ -49,7 +51,11 @@ of using live-binding, we could listen to when offset changes and update the pag
 
 @demo demos/can-component/paginate_events_next_update_page.html
 
-Components have the ability to bind to special inserted and removed events that are called when a component’s tag has been inserted into or removed from the page:
+### Special events: inserted and removed
+
+In previous versions of CanJS, components had the ability to bind to special
+`inserted` and `removed` events that were called when a component’s element had
+been inserted into or removed from the page:
 
 ```js
 {
@@ -66,13 +72,19 @@ Components have the ability to bind to special inserted and removed events that 
 }
 ```
 
+You can still bind to these special events by using the
+[can-3-4-compat](https://www.npmjs.com/package/can-3-4-compat) package, but this
+is deprecated in favor of the new [can-component/connectedCallback] API. See
+more information about migrating away from the inserted and removed events in
+the [migrate-4] guide.
+
 ## High performance view rendering
 
 While [can-stache-bindings] conveniently allows you to call a [can-component::ViewModel] method from a view like:
 
 ```html
-<input ($change)="doSomething()"/>
-``
+<input on:change="doSomething()"/>
+```
 
 This has the effect of binding an event handler directly to this element. Every element that has a `on:click` or similar attribute has an event handler bound to it. For a large grid or list, this could have a performance penalty.
 

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -11,15 +11,11 @@ properties and methods.  Registers the component by its [can-component::tag] wit
 
 ```js
 import Component from "can-component";
-import stache from "can-stache";
-import DefineMap from "can-define/map/map";
-
-const VM = DefineMap.extend( { /* ... */ } );
 
 Component.extend( {
 	tag: "tag-name",
-	ViewModel: VM,
-	view: stache( " /* ... */ " )
+	ViewModel: { /* ... */ },
+	view: " /* ... */ "
 } );
 ```
 

--- a/docs/leakscope.md
+++ b/docs/leakscope.md
@@ -19,11 +19,13 @@ The default value is `false`.
 To change leakScope from the default:
 
 ```js
+import Component from "can-component";
+
 Component.extend( {
 	tag: "my-component",
 	leakScope: true,
-	ViewModel: { message: { value: "Hello World!" } },
-	view: stache( "{{message}}" )
+	ViewModel: { message: { default: "Hello World!" } },
+	view: "{{message}}"
 } );
 ```
 
@@ -59,7 +61,7 @@ Finally, if `<hello-world>` is defined like:
 ```js
 Component.extend( {
 	tag: "hello-world",
-	view: stache( "{{greeting}} <content/>{{exclamation}}" )
+	view: "{{greeting}} <content/>{{exclamation}}"
 } );
 ```
 
@@ -115,7 +117,7 @@ If the following component is defined:
 Component.extend( {
 	tag: "hello-world",
 	leakScope: true, // changed to true instead of the default value
-	ViewModel: { name: { value: "World" } },
+	ViewModel: { name: { default: "World" } },
 	view: "Hello <content />"
 } );
 ```

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -7,5 +7,3 @@ Specifies the HTML tag (or node-name) the [can-component] will be created on.
 will be created on.  Tag names are typically lower cased and
 hyphenated like: `foo-bar`.  Components register their
 tag with [can-view-callbacks.tag tag].
-
-

--- a/docs/view-model.md
+++ b/docs/view-model.md
@@ -17,7 +17,9 @@ need to be setup.
 
 ```js
 import Component from "can-component";
+import DefineMap from "can-define/map/map";
 import Scope from "can-view-scope";
+import stache from "can-stache";
 
 Component.extend( {
 	tag: "my-element",
@@ -93,5 +95,5 @@ This example should be done with the [can-component::events] object instead.
 
 @return {Map|Object} Returns one of the following.
 
-   - An observable map or list type.
-   - The prototype of an observable map or list type that will be used to render the component’s view.
+	 - An observable map or list type.
+	 - The prototype of an observable map or list type that will be used to render the component’s view.

--- a/docs/view.md
+++ b/docs/view.md
@@ -4,12 +4,28 @@
 Provides a view to render directly within the component’s element. The view is rendered with the
 component’s [can-component::ViewModel] instance.  `<content/>` elements within the view are replaced by the source elements within the component’s tag.
 
-@option {can-stache.renderer} A [can-stache.renderer] returned by [can-stache]. For example:
+@option {can-stache.renderer} A [can-stache.renderer] returned by [can-stache] or a String that will be passed to [can-stache].
+
+For example:
 
 ```js
-Component( {
+import Component from "can-component";
+import stache from "can-stache";
+
+Component.extend( {
 	tag: "my-tabs",
 	view: stache( "<ul>{{#panels}}<li>{{title}}</li> /* ... */" )
+} );
+```
+
+…can be written as:
+
+```js
+import Component from "can-component";
+
+Component.extend( {
+	tag: "my-tabs",
+	view: "<ul>{{#panels}}<li>{{title}}</li> /* ... */"
 } );
 ```
 
@@ -38,14 +54,14 @@ The following explains how each part works:
 __Component:__
 
 ```js
-Component( {
+Component.extend( {
 	tag: "my-greeting",
-	view: stache( "<h1><content/> - {{title}}</h1>" ),
-	ViewModel: DefineMap.extend( {
+	view: "<h1><content/> - {{title}}</h1>",
+	ViewModel: {
 		title: {
-			value: "can-component"
+			default: "can-component"
 		}
-	} )
+	}
 } );
 ```
 
@@ -58,9 +74,9 @@ __Source view:__
 
 ```html
 <header>
-  <my-greeting>
-     {{site}}
-  </my-greeting>
+	<my-greeting>
+		 {{site}}
+	</my-greeting>
 </header>
 ```
 
@@ -87,9 +103,9 @@ __HTML Result:__
 
 ```html
 <header>
-  <my-greeting>
-    <h1>CanJS - can-component</h1>
-  </my-greeting>
+	<my-greeting>
+		<h1>CanJS - can-component</h1>
+	</my-greeting>
 </header>
 ```
 
@@ -108,9 +124,9 @@ The view specified by `view` is rendered directly within the custom tag.
 For example the following component:
 
 ```js
-Component( {
+Component.extend( {
 	tag: "my-greeting",
-	view: stache( "<h1>Hello There</h1>" )
+	view: "<h1>Hello There</h1>"
 } );
 ```
 
@@ -118,7 +134,7 @@ With the following source html:
 
 ```html
 <header>
-  <my-greeting></my-greeting>
+	<my-greeting></my-greeting>
 </header>
 ```
 
@@ -126,7 +142,7 @@ Produces the following html:
 
 ```html
 <header>
-  <my-greeting><h1>Hello There</h1></my-greeting>
+	<my-greeting><h1>Hello There</h1></my-greeting>
 </header>
 ```
 
@@ -134,7 +150,7 @@ However, if there was existing content within the source html, like:
 
 ```html
 <header>
-  <my-greeting>DO REMOVE ME!!!</my-greeting>
+	<my-greeting>DO REMOVE ME!!!</my-greeting>
 </header>
 ```
 
@@ -142,7 +158,7 @@ However, if there was existing content within the source html, like:
 
 ```html
 <header>
-  <my-greeting><h1>Hello There</h1></my-greeting>
+	<my-greeting><h1>Hello There</h1></my-greeting>
 </header>
 ```
 
@@ -153,9 +169,9 @@ component’s element within the component’s
 view. For example, if we change the component to look like:
 
 ```js
-Component( {
+Component.extend( {
 	tag: "my-greeting",
-	view: stache( "<h1><content/></h1>" )
+	view: "<h1><content/></h1>"
 } );
 ```
 
@@ -178,9 +194,9 @@ between the `<content>` tags will be used. For example, if we
 change the component to look like:
 
 ```js
-Component( {
+Component.extend( {
 	tag: "my-greeting",
-	view: stache( "<h1><content>Hello World</content></h1>" )
+	view: "<h1><content>Hello World</content></h1>"
 } );
 ```
 


### PR DESCRIPTION
- Remove DefineMap.extend() and stache() where possible
- Use default instead of value
- Use template literals instead of concatenating strings for templates
- Add migration info to the events docs
- Various other improvements

**Most of the changes are fairly straightforward, so I added comments to the parts that I would really like reviewed.**

Closes https://github.com/canjs/can-component/issues/196
Closes https://github.com/canjs/can-component/issues/244
Closes https://github.com/canjs/can-component/issues/259