### PR TITLE
Updates to programatic component instantiation

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -374,20 +374,20 @@ var Component = Construct.extend(
 				componentTagData.scope = new Scope(componentScope);
 			}
 
-			// Hook up any templates with which the component was instantiated
-			var componentTemplates = componentTagData.templates;
-			if (componentTemplates !== undefined) {
+			// Hook up any partials with which the component was instantiated
+			var componentPartials = componentTagData.partials;
+			if (componentPartials !== undefined) {
 				options.partials = {};
-				for (var name in componentTemplates) {
-					var template = componentTemplates[name];
+				for (var name in componentPartials) {
+					var partial = componentPartials[name];
 
 					// Check if it’s already a renderer function or
 					// a string that needs to be parsed by stache
-					if (typeof template === "function") {
-						options.partials[name] = template;
-					} else if (typeof template === "string") {
+					if (typeof partial === "function") {
+						options.partials[name] = partial;
+					} else if (typeof partial === "string") {
 						var debugName = string.capitalize( string.camelize(name) ) + "Template";
-						options.partials[name] = stache(debugName, template);
+						options.partials[name] = stache(debugName, partial);
 					}
 				}
 			}

--- a/can-component.js
+++ b/can-component.js
@@ -199,7 +199,7 @@ function getSetupFunctionForComponentVM(componentInitVM) {
 				}
 
 				// Like can-stache-bindings, delay starting the rest of the binding
-				onCompleteBindings.push(canBinding.start);
+				onCompleteBindings.push(canBinding.start.bind(canBinding));
 
 				// We’ll want to turn off the bindings when the component is destroyed
 				onTeardowns.push(canBinding.stop);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "can-reflect": "^1.6.0",
     "can-simple-map": "^4.1.0",
     "can-simple-observable": "^2.0.0",
-    "can-stache": "^4.6.0-pre.1",
+    "can-stache": "^4.8.0-pre.1",
     "can-stache-bindings": "^4.0.3",
     "can-stache-key": "^1.0.0",
     "can-string": "<2.0.0",

--- a/test/component-can-bind-test.js
+++ b/test/component-can-bind-test.js
@@ -1,0 +1,66 @@
+var Bind = require("can-bind");
+var Component = require("can-component");
+var helpers = require("./helpers");
+var QUnit = require("steal-qunit");
+var SimpleMap = require("can-simple-map");
+var stache = require("can-stache");
+var value = require("can-value");
+
+QUnit.module("can-component integration with can-bind");
+
+QUnit.test("Using can-bind in connectedCallback works as documented", function(assert) {
+	var done = assert.async();
+
+	// This component is similar to what’s shown as an example in can-bind’s docs
+	var BindComponent = Component.extend({
+		tag: "bind-component",
+		view: "{{object.prop}}",
+		ViewModel: {
+			eventualProp: {
+				default: undefined
+			},
+			object: {
+				default: function() {
+					return new SimpleMap({
+						prop: 15
+					});
+				}
+			},
+			connectedCallback: function() {
+				var binding = new Bind({
+					parent: value.from(this, "eventualProp"),
+					child: value.to(this, "object.prop")
+				});
+				binding.start();
+				return binding.stop.bind(binding);
+			}
+		}
+	});
+
+	// Create a new instance of our component
+	var componentInstance = new BindComponent({});
+	var element = componentInstance.element;
+	var viewModel = componentInstance.viewModel;
+
+	// Initial component values are correct
+	assert.equal(viewModel.object.get("prop"), 15, "view model prop starts off with initial value");
+
+	// Insert the component into the page; connectedCallback will run
+	var fixture = document.getElementById("qunit-fixture");
+	fixture.appendChild(element);
+	helpers.afterMutation(function() {
+
+		// Because this is a one-way parent-to-child binding, the child will be set
+		// to the parent’s value (undefined)
+		assert.equal(viewModel.object.get("prop"), undefined, "binding updates view model prop");
+
+		// When the eventualProp (parent) changes, the object.prop (child) should be updated
+		viewModel.eventualProp = 22;
+		assert.equal(viewModel.object.get("prop"), 22, "new value for one prop updates the other");
+
+		// Clean up
+		fixture.removeChild(element);
+
+		done();
+	});
+});

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -117,9 +117,9 @@ QUnit.test("Components can be instantiated with <content> - with scope - leakSco
 	QUnit.equal(element.innerHTML, "Hello <em>world</em>", "content is rendered with the component’s scope");
 });
 
-QUnit.test("Components can be instantiated with templates", function() {
+QUnit.test("Components can be instantiated with partials", function() {
 	var ComponentConstructor = Component.extend({
-		tag: "new-instantiation-templates",
+		tag: "new-instantiation-partials",
 		view: "Hello {{message}} {{>message-input}}",
 		ViewModel: {
 			message: {default: "world"}
@@ -127,7 +127,7 @@ QUnit.test("Components can be instantiated with templates", function() {
 	});
 
 	var componentInstance = new ComponentConstructor({
-		templates: {
+		partials: {
 			"message-input": "<input value:bind='message' />"
 		}
 	});
@@ -203,7 +203,7 @@ QUnit.test("Components can be instantiated with all options", function() {
 	// Our component
 	var HelloWorld = Component.extend({
 		tag: "hello-world",
-		view: "Hello <content>world</content> <ul>{{#each(items)}} {{>item-partial}} {{/each}}</ul>",
+		view: "Hello <content>world</content> <ul>{{#each(items)}} {{>itemPartial}} {{/each}}</ul>",
 		ViewModel: {
 			items: {
 				default: function() {
@@ -219,8 +219,8 @@ QUnit.test("Components can be instantiated with all options", function() {
 		scope: {
 			message: "friend"
 		},
-		templates: {
-			"item-partial": "<li>{{this}}</li>"
+		partials: {
+			itemPartial: "<li>{{this}}</li>"
 		},
 		viewModel: {
 			items: ["eat", "sleep", "code"]
@@ -236,6 +236,14 @@ QUnit.test("Components can be instantiated with all options", function() {
 		"element renders correctly"
 	);
 	QUnit.equal(viewModel.items.length, 3, "viewModel has items");
+
+	// Changing the view model updates the element
+	viewModel.items.push("repeat");
+	QUnit.equal(
+		element.innerHTML,
+		"Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li>  <li>code</li>  <li>repeat</li> </ul>",
+		"element updates correctly"
+	);
 });
 
 QUnit.test("Component binding instantiation works as documented", function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,3 +9,4 @@ require('./component-slot-test');
 require('./component-define-test');
 require("./component-instantiation-test");
 require("./component-in-stache-test");
+require("./component-can-bind-test");


### PR DESCRIPTION
[The docs are currently available on the 5.0 site.](https://canjs.github.io/next/doc/can-component.html)

- Add a reason why you would want programatic instantiation to the signature docs
- Remove unnecessary inner `new DefineMap`
- Move `viewModel` up in the signature example (and in the docs below)
- Use the key “partials” (instead of “templates”) when programmatically instantiating components
- Update examples to use camelCase instead of hyphen-case for partial names
- Show how changing a component’s viewModel will update its element
- Reformat some comments