### PR TITLE
Upgrade to can-stache-bindings@5

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -40,6 +40,8 @@ var domMutateNode = require('can-dom-mutate/node');
 var canSymbol = require('can-symbol');
 var DOCUMENT = require('can-globals/document/document');
 
+stache.addBindings(stacheBindings);
+
 // For insertion elements like <can-slot> and <context>, this will add
 // a compute viewModel to the top of the context if
 // a binding like {this}="value" is present.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "can-simple-map": "^4.1.0",
     "can-simple-observable": "^2.0.0",
     "can-stache": "^4.1.0",
-    "can-stache-bindings": "^4.0.3",
+    "can-stache-bindings": "^5.0.0-pre.0",
     "can-stache-key": "^1.0.0",
     "can-string": "0.0.5",
     "can-symbol": "^1.4.1",


### PR DESCRIPTION
This upgrades can-component to use can-stache-bindings@5, and enables
the bindings. Closes #263