### PR TITLE
Allow components to be instantiated with slot templates

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -377,15 +377,13 @@ var Component = Construct.extend(
 			// Hook up any templates with which the component was instantiated
 			var componentTemplates = componentTagData.templates;
 			if (componentTemplates !== undefined) {
-				for (var name in componentTemplates) {
-					var template = componentTemplates[name];
-
+				canReflect.eachKey(componentTemplates, function(template, name) {
 					// Check if it’s a string that needs to be parsed by stache
 					if (typeof template === "string") {
 						var debugName = name + " template";
 						componentTemplates[name] = stache(debugName, template);
 					}
-				}
+				});
 			}
 
 			// an array of teardown stuff that should happen when the element is removed

--- a/can-component.js
+++ b/can-component.js
@@ -374,20 +374,16 @@ var Component = Construct.extend(
 				componentTagData.scope = new Scope(componentScope);
 			}
 
-			// Hook up any partials with which the component was instantiated
-			var componentPartials = componentTagData.partials;
-			if (componentPartials !== undefined) {
-				options.partials = {};
-				for (var name in componentPartials) {
-					var partial = componentPartials[name];
+			// Hook up any templates with which the component was instantiated
+			var componentTemplates = componentTagData.templates;
+			if (componentTemplates !== undefined) {
+				for (var name in componentTemplates) {
+					var template = componentTemplates[name];
 
-					// Check if it’s already a renderer function or
-					// a string that needs to be parsed by stache
-					if (typeof partial === "function") {
-						options.partials[name] = partial;
-					} else if (typeof partial === "string") {
-						var debugName = string.capitalize( string.camelize(name) ) + "Template";
-						options.partials[name] = stache(debugName, partial);
+					// Check if it’s a string that needs to be parsed by stache
+					if (typeof template === "string") {
+						var debugName = name + " template";
+						componentTemplates[name] = stache(debugName, template);
 					}
 				}
 			}

--- a/docs/component.md
+++ b/docs/component.md
@@ -90,13 +90,15 @@ element by calling `new` on the component’s constructor function:
 
 ```js
 const HelloWorld = Component.extend({
-  tag: "hello-world",
-  view: "Hello <content>world</content> <ul>{{#each(items)}} {{>itemPartial}} {{/each}}</ul>",
-  ViewModel: {
-    items: {
-      default: () => []
-    }
-  }
+	tag: "hello-world",
+	view: `
+		<can-slot name="greetingTemplate" />
+		<content>world</content>
+		<ul>{{#each(items)}} {{this}} {{/each}}</ul>
+	`,
+	ViewModel: {
+		items: {}
+	}
 });
 
 // Create a new instance of our component
@@ -104,45 +106,46 @@ const componentInstance = new HelloWorld({
 
 	// values with which to initialize the component’s view model
 	viewModel: {
-		items: ["eat", "sleep", "code"]
+		items: ["eat"]
 	},
 
 	// can-stache template to replace any <content> elements in the component’s view
 	content: "<em>{{message}}</em>",
 
-	// scope with which to render the <content>
-	scope: {
-		message: "friend"
+	// <can-template> strings rendered by can-stache with the scope
+	templates: {
+		greetingTemplate: "{{greeting}}"
 	},
 
-	// partials made available to the component’s view
-	partials: {
-		itemPartial: "<li>{{this}}</li>"
+	// scope with which to render the <content> and templates
+	scope: {
+		greeting: "Hello",
+		message: "friend"
 	}
 });
 
-myGreetingInstance.element; // is <my-greeting>Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li>  <li>code</li> </ul></my-greeting>
+myGreetingInstance.element; // is like <my-greeting>Hello <em>friend</em> <ul> <li>eat</li> </ul></my-greeting>
 
-myGreetingInstance.viewModel; // is HelloWorld.ViewModel{items: ["eat", "sleep", "code"]}
+myGreetingInstance.viewModel; // is HelloWorld.ViewModel{items: ["eat"]}
 ```
 
 Changing the component’s view model will cause its element and any bindings to
 be updated:
 
 ```js
-myGreetingInstance.viewModel.items.push("repeat");
+myGreetingInstance.viewModel.items.push("sleep");
 
-myGreetingInstance.element; // is <my-greeting>Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li>  <li>code</li>  <li>repeat</li> </ul></my-greeting>
+myGreetingInstance.element; // is like <my-greeting>Hello <em>friend</em> <ul> <li>eat</li> <li>sleep</li> </ul></my-greeting>
 ```
 
 See the [Programmatically instantiating a component](#Programmaticallyinstantiatingacomponent)
 section for details.
 
 @param {Object} [options] Options for rendering the component, including:
-- **content** `{String|Function}`: similar to the [can-component/content] tag, the `LIGHT_DOM` to be rendered between the component’s starting and ending tags; can either be a string (which will be parsed by [can-stache] by default) or a [can-stache.renderer] function.
-- **partials** `{Object<String,String|Function>}`: an object that has keys that are partial names and values that are either plain strings (parsed by [can-stache] by default) or [can-stache.renderer] functions.
-- **scope** `{Object}`: an object that is the scope with which the content should be rendered.
-- **viewModel** `{Object}`: an object with values to bind to the component’s view model.
+- **content** `{String|Function}`: Similar to the [can-component/content] tag, the `LIGHT_DOM` to be rendered between the component’s starting and ending tags; can either be a string (which will be parsed by [can-stache] by default) or a [can-stache.renderer] function.
+- **scope** `{Object}`: An object that is the scope with which the content should be rendered.
+- **templates** `{Object<String,String|Function>}`: An object that has keys that are [can-component/can-template] names and values that are either plain strings (parsed by [can-stache] by default) or [can-stache.renderer] functions.
+- **viewModel** `{Object}`: An object with values to bind to the component’s view model.
 
   @release 4.3
 
@@ -481,7 +484,7 @@ myGreetingInstance.viewModel; // is MyGreeting.ViewModel{subject: "friend"}
 In the example above, the `viewModel` is passed in as an option to the
 component’s constructor function.
 
-In addition to `viewModel`, there are `scope`, `partials`, and `content`
+In addition to `viewModel`, there are `templates`, `scope`, and `content`
 options. Read below for details on all the options.
 
 ### viewModel
@@ -644,28 +647,26 @@ This would make `helloWorldInstance.element` a fragment with the following struc
 <hello-world>Hello <em>mundo</em></hello-world>
 ```
 
-### partials
+### templates
 
-The `partials` option is used to pass a partial into a
+The `templates` option is used to pass a [can-component/can-template] into a
 component when it is instantiated.
 
 ```js
 import Component from "can-component";
 
 const TodosPage = Component.extend({
-  tag: "todos-page",
-  view: "<ul>{{#each(items)}} {{>itemPartial}} {{/each}}</ul>",
-  ViewModel: {
-    items: {
-      default: () => ["eat", "sleep", "code"]
-    }
-  }
+	tag: "todos-page",
+	view: "<ul><can-slot name='itemList' /></ul>"
 });
 
 const todosPageInstance = new TodosPage({
-  partials: {
-    itemPartial: "<li>{{name}}</li>"
-  }
+	scope: {
+		items: ["eat"]
+	},
+	templates: {
+		itemList: "{{#each(items)}} <li>{{this}}</li> {{/each}}"
+	}
 });
 ```
 
@@ -675,8 +676,6 @@ This would make `todosPageInstance.element` a fragment with the following struct
 <todos-page>
   <ul>
     <li>eat</li>
-    <li>sleep</li>
-    <li>code</li>
   </ul>
 </todos-page>
 ```

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -117,18 +117,19 @@ QUnit.test("Components can be instantiated with <content> - with scope - leakSco
 	QUnit.equal(element.innerHTML, "Hello <em>world</em>", "content is rendered with the component’s scope");
 });
 
-QUnit.test("Components can be instantiated with partials", function() {
+QUnit.test("Components can be instantiated with templates", function() {
 	var ComponentConstructor = Component.extend({
-		tag: "new-instantiation-partials",
-		view: "Hello {{message}} {{>message-input}}",
-		ViewModel: {
-			message: {default: "world"}
-		}
+		tag: "new-instantiation-templates",
+		view: "<can-slot name='messageInput' />"
 	});
 
+	var scopeVM = new DefineMap({
+		message: "world"
+	});
 	var componentInstance = new ComponentConstructor({
-		partials: {
-			"message-input": "<input value:bind='message' />"
+		scope: scopeVM,
+		templates: {
+			messageInput: "<input value:bind='message' />"
 		}
 	});
 
@@ -138,11 +139,9 @@ QUnit.test("Components can be instantiated with partials", function() {
 	QUnit.ok(inputElement, "template rendered");
 	QUnit.equal(inputElement.value, "world", "input has correct value");
 
-	// Updating the viewModel should update the template
-	var viewModel = componentInstance.viewModel;
-	viewModel.message = "mundo";
-	QUnit.equal(element.textContent, "Hello mundo ", "element has correct text content after updating viewModel");
-	QUnit.equal(inputElement.value, "mundo", "input has correct value after updating viewModel");
+	// Updating the scopeVM should update the template
+	scopeVM.message = "mundo";
+	QUnit.equal(inputElement.value, "mundo", "input has correct value after updating scopeVM");
 });
 
 QUnit.test("Components can be instantiated with viewModel", function() {
@@ -203,13 +202,9 @@ QUnit.test("Components can be instantiated with all options", function() {
 	// Our component
 	var HelloWorld = Component.extend({
 		tag: "hello-world",
-		view: "Hello <content>world</content> <ul>{{#each(items)}} {{>itemPartial}} {{/each}}</ul>",
+		view: "Hello <content>world</content> <ul>{{#each(items)}} <can-slot name='itemTemplate' this:from='this' /> {{/each}}</ul>",
 		ViewModel: {
-			items: {
-				default: function() {
-					return [];
-				}
-			}
+			items: {}
 		}
 	});
 
@@ -219,11 +214,11 @@ QUnit.test("Components can be instantiated with all options", function() {
 		scope: {
 			message: "friend"
 		},
-		partials: {
-			itemPartial: "<li>{{this}}</li>"
+		templates: {
+			itemTemplate: "<li>{{this}}</li>"
 		},
 		viewModel: {
-			items: ["eat", "sleep", "code"]
+			items: ["eat"]
 		}
 	});
 	var element = componentInstance.element;
@@ -232,16 +227,16 @@ QUnit.test("Components can be instantiated with all options", function() {
 	// Basics look correct
 	QUnit.equal(
 		element.innerHTML,
-		"Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li>  <li>code</li> </ul>",
+		"Hello <em>friend</em> <ul> <li>eat</li> </ul>",
 		"element renders correctly"
 	);
-	QUnit.equal(viewModel.items.length, 3, "viewModel has items");
+	QUnit.equal(viewModel.items.length, 1, "viewModel has items");
 
 	// Changing the view model updates the element
-	viewModel.items.push("repeat");
+	viewModel.items.push("sleep");
 	QUnit.equal(
 		element.innerHTML,
-		"Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li>  <li>code</li>  <li>repeat</li> </ul>",
+		"Hello <em>friend</em> <ul> <li>eat</li>  <li>sleep</li> </ul>",
 		"element updates correctly"
 	);
 });


### PR DESCRIPTION
This makes it possible to initialize a component with a `templates` option that functions similarly to `<can-template>`:

```js
import Component from "can-component";

const MyApp = Component.extend({
  tag: "my-app",
  view: "<can-slot name='subject' />"
});

const appInstance = new MyApp({
  scope: {
    message: "Hello"
  },
  templates: {
    subject: "{{message}}"
  }
});
```

This would result in `appInstance.element` looking like:

```html
<my-app>Hello</my-app>
```

This commit also:

- Removes passing `partials` when creating a component
- Has other small changes to the docs

Closes https://github.com/canjs/can-component/issues/262