### PR TITLE
Fix bug where connectedCallback gets called twice for `new Components({ ... })`

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -44,6 +44,7 @@ var canSymbol = require('can-symbol');
 var DOCUMENT = require('can-globals/document/document');
 
 // Symbols
+var createdByCanComponentSymbol = canSymbol("can.createdByCanComponent");
 var getValueSymbol = canSymbol.for("can.getValue");
 var setValueSymbol = canSymbol.for("can.setValue");
 var viewInsertSymbol = canSymbol.for("can.viewInsert");
@@ -321,8 +322,12 @@ var Component = Construct.extend(
 				}
 
 				// Register this component to be created when its `tag` is found.
-				viewCallbacks.tag(this.prototype.tag, function(el, options) {
-					new self(el, options);
+				viewCallbacks.tag(this.prototype.tag, function(el, tagData) {
+					// Check if a symbol already exists on the element; if it does, then
+					// a new instance of the component has already been created
+					if (el[createdByCanComponentSymbol] === undefined) {
+						new self(el, tagData);
+					}
 				});
 			}
 		}
@@ -346,13 +351,14 @@ var Component = Construct.extend(
 					componentTagData = {};
 				} else {
 					componentTagData = el;
-					el = null;
+					el = undefined;
 				}
 			}
 
 			// Create an element if it doesn’t exist and make it available outside of this
-			if (!el) {
-				el = document.createElement(this.tag);
+			if (el === undefined) {
+				el = DOCUMENT().createElement(this.tag);
+				el[createdByCanComponentSymbol] = true;
 			}
 			this.element = el;
 

--- a/test/component-can-bind-test.js
+++ b/test/component-can-bind-test.js
@@ -11,6 +11,9 @@ QUnit.module("can-component integration with can-bind");
 QUnit.test("Using can-bind in connectedCallback works as documented", function(assert) {
 	var done = assert.async();
 
+	// This will be used to count the number of times connectedCallback is called
+	var connectedCallbackCallCount = 0;
+
 	// This component is similar to what’s shown as an example in can-bind’s docs
 	var BindComponent = Component.extend({
 		tag: "bind-component",
@@ -27,6 +30,7 @@ QUnit.test("Using can-bind in connectedCallback works as documented", function(a
 				}
 			},
 			connectedCallback: function() {
+				connectedCallbackCallCount += 1;
 				var binding = new Bind({
 					parent: value.from(this, "eventualProp"),
 					child: value.to(this, "object.prop")
@@ -57,6 +61,9 @@ QUnit.test("Using can-bind in connectedCallback works as documented", function(a
 		// When the eventualProp (parent) changes, the object.prop (child) should be updated
 		viewModel.eventualProp = 22;
 		assert.equal(viewModel.object.get("prop"), 22, "new value for one prop updates the other");
+
+		// Check to make sure connectedCallback was only called once
+		assert.equal(connectedCallbackCallCount, 1, "connectedCallback only called once");
 
 		// Clean up
 		fixture.removeChild(element);


### PR DESCRIPTION
When a component is programmatically instantiated and its element is inserted into the DOM, two callbacks run:

- can-view-callbacks.tag (because it listens for the custom element to be inserted into the DOM) https://github.com/canjs/can-component/blob/b60dbf6c4fda12318eab4c7f513fb3081a4122e6/can-component.js#L324-L326
- can-dom-mutate.onNodeInsertion (because the element wasn’t in the DOM when it was created, but does get inserted later) https://github.com/canjs/can-component/blob/b60dbf6c4fda12318eab4c7f513fb3081a4122e6/can-component.js#L578-L581

This caused connectedCallback to be called twice.

This PR fixes that by checking in the can-view-callbacks.tag callback whether the component’s element has a symbol that’s added when the component’s constructor function runs.