### PR TITLE
Ie11 compat

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -487,7 +487,7 @@ var Component = Construct.extend(
 				});
 			} else {
 				var removalDisposal = domMutate.onNodeRemoval(el, function () {
-					if (!el.ownerDocument.contains(el)) {
+					if (!el.ownerDocument.documentElement.contains(el)) {
 						removalDisposal();
 						callTeardownFunctions();
 					}

--- a/test/component-define-test.js
+++ b/test/component-define-test.js
@@ -204,7 +204,7 @@ QUnit.test("ViewModel properties default to DefineList if set to an Array (#225)
 		view: "Hello, World",
 		ViewModel: {
 			items: {
-				default() {
+				default: function() {
 					return [ "one", "two" ];
 				}
 			}

--- a/test/component-slot-test.js
+++ b/test/component-slot-test.js
@@ -486,7 +486,7 @@ QUnit.test("able to pass individual values (#291)", function() {
 
 	var frag = template();
 
-	var passValuesToSlots = frag.firstElementChild;
+	var passValuesToSlots = frag.firstElementChild || frag.firstChild;
 	passValuesToSlots.viewModel.add(5);
 	var count = passValuesToSlots.querySelector(".count");
 

--- a/test/component-view-test.js
+++ b/test/component-view-test.js
@@ -170,7 +170,7 @@ helpers.makeTests("can-component views", function(doc, runTestInOnlyDocument){
         Component.extend({
             tag: 'child-tag',
 
-            ViewModel: SimpleMap.extend({
+            ViewModel: DefineMap.extend({
                 init: function () {
                     inited++;
                 }
@@ -187,8 +187,8 @@ helpers.makeTests("can-component views", function(doc, runTestInOnlyDocument){
 
             view: stache('{{#shown}}<child-tag></child-tag>{{/shown}}'),
 
-            viewModel: observe.Object.extend("ParentTag",{},{
-                shown: false
+            viewModel: DefineMap.extend("ParentTag",{},{
+                shown: { default: false }
             }),
             events: {
                 ' inserted': function () {

--- a/test/component-viewmodel-test.js
+++ b/test/component-viewmodel-test.js
@@ -20,40 +20,40 @@ var observe = require("can-observe");
 var tag = require('can-view-callbacks').tag;
 
 var innerHTML = function(el){
-    return el && el.innerHTML;
+	return el && el.innerHTML;
 };
 
 helpers.makeTests("can-component viewModels", function(){
 
-    QUnit.test("a SimpleMap constructor as .ViewModel", function() {
+	QUnit.test("a SimpleMap constructor as .ViewModel", function() {
 
-        var map = new SimpleMap({name: "Matthew"});
+		var map = new SimpleMap({name: "Matthew"});
 
-        Component.extend({
-            tag: "can-map-viewmodel",
-            view: stache("{{name}}"),
-            ViewModel: function(){
-                return map;
-            }
-        });
+		Component.extend({
+			tag: "can-map-viewmodel",
+			view: stache("{{name}}"),
+			ViewModel: function(){
+				return map;
+			}
+		});
 
-        var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
-        equal(renderer().firstChild.firstChild.nodeValue, "Matthew");
-    });
+		var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
+		equal(renderer().firstChild.firstChild.nodeValue, "Matthew");
+	});
 
 
 
 	QUnit.test("a SimpleMap as viewModel", function () {
 
 		var me = new SimpleMap({
-			name: "Justin"
-		});
+		 name: "Justin"
+	 });
 
 		Component.extend({
-			tag: 'my-viewmodel',
-			view: stache("{{name}}}"),
-			viewModel: me
-		});
+		 tag: 'my-viewmodel',
+		 view: stache("{{name}}}"),
+		 viewModel: me
+	 });
 
 		var renderer = stache('<my-viewmodel></my-viewmodel>');
 		equal(renderer().firstChild.firstChild.nodeValue, "Justin");
@@ -62,17 +62,17 @@ helpers.makeTests("can-component viewModels", function(){
 
 	QUnit.test("a SimpleMap constructor as viewModel", function() {
 		var MyMap = SimpleMap.extend({
-			setup: function(props){
-                props.name = "Matthew";
-                return SimpleMap.prototype.setup.apply(this, arguments);
-            }
-		});
+		 setup: function(props){
+			props.name = "Matthew";
+			return SimpleMap.prototype.setup.apply(this, arguments);
+		}
+	});
 
 		Component.extend({
-			tag: "can-map-viewmodel",
-			view: stache("{{name}}"),
-			viewModel: MyMap
-		});
+		 tag: "can-map-viewmodel",
+		 view: stache("{{name}}"),
+		 viewModel: MyMap
+	 });
 
 		var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
 		equal(renderer().firstChild.firstChild.nodeValue, "Matthew");
@@ -80,12 +80,12 @@ helpers.makeTests("can-component viewModels", function(){
 
 	QUnit.test("an object is turned into a SimpleMap as viewModel", function() {
 		Component.extend({
-			tag: "can-map-viewmodel",
-			view: stache("{{name}}"),
-			viewModel: {
-                name: "Matthew"
-			}
-		});
+		 tag: "can-map-viewmodel",
+		 view: stache("{{name}}"),
+		 viewModel: {
+			name: "Matthew"
+		}
+	});
 
 		var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
 
@@ -102,79 +102,79 @@ helpers.makeTests("can-component viewModels", function(){
 
 	test("Providing viewModel and ViewModel throws", function() {
 		try {
-			Component.extend({
-				tag: "viewmodel-test",
-				view: stache("<div></div>"),
-				viewModel: {},
-				ViewModel: SimpleMap.extend({})
-			});
+		 Component.extend({
+			tag: "viewmodel-test",
+			view: stache("<div></div>"),
+			viewModel: {},
+			ViewModel: SimpleMap.extend({})
+		});
 
-			ok(false, "Should have thrown because we provided both");
-		} catch(er) {
-			ok(true, "It threw because we provided both viewModel and ViewModel");
-		}
+		 ok(false, "Should have thrown because we provided both");
+	 } catch(er) {
+		 ok(true, "It threw because we provided both viewModel and ViewModel");
+	 }
+ });
+
+	test("canViewModel utility", function() {
+		Component({
+			tag: "my-taggy-tag",
+			view: stache("<h1>hello</h1>"),
+			viewModel: function(){
+				return new SimpleMap({
+					foo: "bar"
+				});
+			}
+		});
+
+		var frag = stache("<my-taggy-tag id='x'></my-taggy-tag>")();
+
+
+		var el = frag.firstChild;
+
+		equal(canViewModel(el), el[canSymbol.for('can.viewModel')], "one argument grabs the viewModel object");
+		equal(canViewModel(el, "foo"), "bar", "two arguments fetches a value");
+		canViewModel(el, "foo", "baz");
+		equal(canViewModel(el, "foo"), "baz", "Three arguments sets the value");
 	});
 
-    test("canViewModel utility", function() {
-        Component({
-            tag: "my-taggy-tag",
-            view: stache("<h1>hello</h1>"),
-            viewModel: function(){
-                return new SimpleMap({
-                    foo: "bar"
-                });
-            }
-        });
-
-        var frag = stache("<my-taggy-tag id='x'></my-taggy-tag>")();
-
-
-        var el = frag.firstChild;
-
-        equal(canViewModel(el), el[canSymbol.for('can.viewModel')], "one argument grabs the viewModel object");
-        equal(canViewModel(el, "foo"), "bar", "two arguments fetches a value");
-        canViewModel(el, "foo", "baz");
-        equal(canViewModel(el, "foo"), "baz", "Three arguments sets the value");
-    });
-
-    test('setting passed variables - two way binding', function () {
+	test('setting passed variables - two way binding', function () {
 		Component.extend({
-			tag: "my-toggler",
-			view: stache("{{#if visible}}<content/>{{/if}}"),
-			leakScope: true,
-			ViewModel: DefineMap.extend({
-				visible: {value: true},
-				show: function () {
-					this.set('visible', true);
-				},
-				hide: function () {
-					this.set("visible", false);
-				}
-			})
-		});
+		 tag: "my-toggler",
+		 view: stache("{{#if visible}}<content/>{{/if}}"),
+		 leakScope: true,
+		 ViewModel: DefineMap.extend({
+			visible: {value: true},
+			show: function () {
+			 this.set('visible', true);
+		 },
+		 hide: function () {
+			 this.set("visible", false);
+		 }
+	 })
+	 });
 
 		Component.extend({
-			tag: "my-app",
-			ViewModel: DefineMap.extend({
-				visible: {value: true},
-				show: function () {
-					this.set('visible', true);
-				}
-			})
-		});
+		 tag: "my-app",
+		 ViewModel: DefineMap.extend({
+			visible: {value: true},
+			show: function () {
+			 this.set('visible', true);
+		 }
+	 })
+	 });
 
 		var renderer = stache("<my-app>" +
-			'{{^visible}}<button on:click="show()">show</button>{{/visible}}' +
-			'<my-toggler visible:bind="visible">' +
-			'content' +
-			'<button on:click="hide()">hide</button>' +
-			'</my-toggler>' +
-			'</my-app>');
+		'{{^visible}}<button on:click="show()">show</button>{{/visible}}' +
+		'<my-toggler visible:bind="visible">' +
+		'content' +
+		'<button on:click="hide()">hide</button>' +
+		'</my-toggler>' +
+		'</my-app>');
 
 		var frag = renderer({});
 
 		var myApp = frag.firstChild,
-			buttons = myApp.getElementsByTagName("button");
+		buttons = myApp.getElementsByTagName("button");
 
 		equal( buttons.length, 1, "there is one button");
 		equal( innerHTML(buttons[0]) , "hide", "the button's text is hide");
@@ -193,83 +193,83 @@ helpers.makeTests("can-component viewModels", function(){
 	});
 
 
-    test("don't update computes unnecessarily", function () {
+	test("don't update computes unnecessarily", function () {
 		var sourceAge = new SimpleObservable(30),
-			timesComputeIsCalled = 0;
+		timesComputeIsCalled = 0;
 
 		var age = new SetterObservable(function () {
-			timesComputeIsCalled++;
-			if (timesComputeIsCalled === 1) {
-				ok(true, "reading initial value to set as years");
-			} else if (timesComputeIsCalled === 3) {
-				ok(true, "called back another time after set to get the value");
-			} else {
-                ok(false, "(getter) You've called the callback " + timesComputeIsCalled + " times");
-            }
+		 timesComputeIsCalled++;
+		 if (timesComputeIsCalled === 1) {
+			ok(true, "reading initial value to set as years");
+		} else if (timesComputeIsCalled === 3) {
+			ok(true, "called back another time after set to get the value");
+		} else {
+			ok(false, "(getter) You've called the callback " + timesComputeIsCalled + " times");
+		}
 
-      console.log("Getting, " + sourceAge.get());
-			return sourceAge.get();
+		console.log("Getting, " + sourceAge.get());
+		return sourceAge.get();
 
-		}, function(newVal){
-      console.log("Setting, " + newVal)
-            timesComputeIsCalled++;
-            if (timesComputeIsCalled === 2) {
-				ok(true, "updating value to " + newVal);
-			} else {
-				ok(false, "(setter) You've called the callback " + timesComputeIsCalled + " times");
-			}
-            sourceAge.set(newVal);
-        });
+	}, function(newVal){
+		console.log("Setting, " + newVal)
+		timesComputeIsCalled++;
+		if (timesComputeIsCalled === 2) {
+			ok(true, "updating value to " + newVal);
+		} else {
+			ok(false, "(setter) You've called the callback " + timesComputeIsCalled + " times");
+		}
+		sourceAge.set(newVal);
+	});
 
 		Component.extend({
-			tag: "age-er"
-		});
+		 tag: "age-er"
+	 });
 
 		var renderer = stache("<age-er years:bind='age'></age-er>");
 
 		renderer({
-			age: age
-		});
+		 age: age
+	 });
 
 		age.set(31);
 
 	});
 
-    test("viewModel not rebound correctly (#550)", function () {
+	test("viewModel not rebound correctly (#550)", function () {
 
-        var nameChanges = 0;
+		var nameChanges = 0;
 
-        Component.extend({
-            tag: "viewmodel-rebinder",
-            events: {
-                "{name}": function () {
-                    nameChanges++;
-                }
-            }
-        });
+		Component.extend({
+			tag: "viewmodel-rebinder",
+			events: {
+				"{name}": function () {
+					nameChanges++;
+				}
+			}
+		});
 
-        var renderer = stache("<viewmodel-rebinder></viewmodel-rebinder>");
+		var renderer = stache("<viewmodel-rebinder></viewmodel-rebinder>");
 
-        var frag = renderer();
-        var viewModel = canViewModel(frag.firstChild);
+		var frag = renderer();
+		var viewModel = canViewModel(frag.firstChild);
 
-        var n1 = new SimpleObservable(),
-            n2 = new SimpleObservable();
+		var n1 = new SimpleObservable(),
+		n2 = new SimpleObservable();
 
-        viewModel.set("name", n1);
+		viewModel.set("name", n1);
 
-        n1.set("updated");
+		n1.set("updated");
 
-        viewModel.set("name", n2);
+		viewModel.set("name", n2);
 
-        n2.set("updated");
+		n2.set("updated");
 
 
-        equal(nameChanges, 2);
-    });
+		equal(nameChanges, 2);
+	});
 
-    /*
-    test("@ keeps properties live now", function () {
+		/*
+		test("@ keeps properties live now", function () {
 
 		Component.extend({
 			tag: "attr-fun",
@@ -300,190 +300,190 @@ helpers.makeTests("can-component viewModels", function(){
 
 	});
 
-    test('component does not update viewModel on id, class, and data-view-id attribute changes (#1079)', function(){
+		test('component does not update viewModel on id, class, and data-view-id attribute changes (#1079)', function(){
 
-        Component.extend({
-            tag:'x-app'
-        });
+				Component.extend({
+						tag:'x-app'
+				});
 
-        var frag=stache('<x-app></x-app>')({});
+				var frag=stache('<x-app></x-app>')({});
 
-        var el = frag.firstChild;
-        var viewModel = canViewModel(el);
+				var el = frag.firstChild;
+				var viewModel = canViewModel(el);
 
-        // element must be inserted, otherwise attributes event will not be fired
-        domMutate.appendChild.call(this.fixture,frag);
+				// element must be inserted, otherwise attributes event will not be fired
+				domMutate.appendChild.call(this.fixture,frag);
 
-        // update the class
-        className.add.call(el,"foo");
+				// update the class
+				className.add.call(el,"foo");
 
-        stop();
-        setTimeout(function(){
-            equal(viewModel.attr('class'),undefined, "the viewModel is not updated when the class attribute changes");
-            start();
-        }, 100);
+				stop();
+				setTimeout(function(){
+						equal(viewModel.attr('class'),undefined, "the viewModel is not updated when the class attribute changes");
+						start();
+				}, 100);
 
-    });
-    */
+		});
+		*/
 
-    test("id and class should work now (#694)", function () {
-		Component.extend({
-			tag: "stay-classy",
-			ViewModel: SimpleMap.extend({
+		test("id and class should work now (#694)", function () {
+			Component.extend({
+			 tag: "stay-classy",
+			 ViewModel: SimpleMap.extend({
 				setup: function(props){
-                    canReflect.assign(props, {
-                        notid: "foo",
-        				notclass: 5,
-        				notdataviewid: {}
-                    });
-                    return SimpleMap.prototype.setup.apply(this, arguments);
-                }
+					canReflect.assign(props, {
+						notid: "foo",
+						notclass: 5,
+						notdataviewid: {}
+					});
+					return SimpleMap.prototype.setup.apply(this, arguments);
+				}
 			})
+		 });
+
+			var data = {
+			 idData: "id-success",
+			 classData: "class-success"
+		 };
+
+		 var frag = stache(
+		 "<stay-classy id:bind='idData'" +
+		 " class:bind='classData'></stay-classy>")(data);
+
+		 var stayClassy = frag.firstChild;
+
+		 domMutateNode.appendChild.call(this.fixture, frag);
+
+		 var viewModel = canViewModel(stayClassy);
+
+		 equal(viewModel.get("id"), "id-success");
+		 equal(viewModel.get("class"), "class-success");
+	 });
+
+		test("Construct are passed normally", function(){
+			var Constructed = Construct.extend({foo:"bar"},{});
+
+			Component.extend({
+				tag: "con-struct",
+				view: stache("{{con.foo}}")
+			});
+
+			var stached = stache("<con-struct con:bind='Constructed'></con-struct>");
+
+			var res = stached({
+				Constructed: Constructed
+			});
+
+			equal(innerHTML(res.firstChild), "bar");
+
+
 		});
 
-		var data = {
-			idData: "id-success",
-			classData: "class-success"
-		};
+		test('Component two way binding loop (#1579)', function() {
+			var changeCount = 0;
 
-		var frag = stache(
-			"<stay-classy id:bind='idData'" +
-			" class:bind='classData'></stay-classy>")(data);
-
-		var stayClassy = frag.firstChild;
-
-		domMutateNode.appendChild.call(this.fixture, frag);
-
-		var viewModel = canViewModel(stayClassy);
-
-		equal(viewModel.get("id"), "id-success");
-		equal(viewModel.get("class"), "class-success");
-	});
-
-    test("Construct are passed normally", function(){
-        var Constructed = Construct.extend({foo:"bar"},{});
-
-        Component.extend({
-            tag: "con-struct",
-            view: stache("{{con.foo}}")
-        });
-
-        var stached = stache("<con-struct con:bind='Constructed'></con-struct>");
-
-        var res = stached({
-            Constructed: Constructed
-        });
-
-        equal(innerHTML(res.firstChild), "bar");
+			Component.extend({
+				tag: 'product-swatch-color',
+				viewModel: {
+					tag: 'product-swatch-color'
+				}
+			});
 
 
-    });
+			Component.extend({
+				tag: 'product-swatch',
+				view: stache('<product-swatch-color variations:bind="variations"></product-swatch-color>'),
+				ViewModel: DefineMap.extend({
 
-    test('Component two way binding loop (#1579)', function() {
-        var changeCount = 0;
+					variations: {
+						set: function(variations) {
+							if(changeCount > 500) {
+								return;
+							}
+							changeCount++;
+							return new DefineList(variations.get());
+						}
+					}
 
-        Component.extend({
-            tag: 'product-swatch-color',
-            viewModel: {
-                tag: 'product-swatch-color'
-            }
-        });
+				})
+			});
 
-
-        Component.extend({
-            tag: 'product-swatch',
-            view: stache('<product-swatch-color variations:bind="variations"></product-swatch-color>'),
-            ViewModel: DefineMap.extend({
-
-                variations: {
-                    set: function(variations) {
-                        if(changeCount > 500) {
-                            return;
-                        }
-                        changeCount++;
-                        return new DefineList(variations.get());
-                    }
-                }
-
-            })
-        });
-
-        var frag = stache('<product-swatch></product-swatch>')(),
-            productSwatch = frag.firstChild;
+			var frag = stache('<product-swatch></product-swatch>')(),
+			productSwatch = frag.firstChild;
 
 
-        canViewModel( productSwatch ).set('variations', new DefineList());
+			canViewModel( productSwatch ).set('variations', new DefineList());
 
 
 
-        ok(changeCount < 500, "more than 500 events");
-    });
-
-
-
-	test('two-way binding syntax INTRODUCED in v2.3 ALLOWS a child property to initialize an undefined parent property', function(){
-		var renderer = stache('<pa-rent/>');
-
-		Component.extend({
-			tag : 'pa-rent',
-			view: stache('<chi-ld childProp:bind="parentProp" />')
+			ok(changeCount < 500, "more than 500 events");
 		});
 
-		Component.extend({
-			tag : 'chi-ld',
-			ViewModel: {
+
+
+		test('two-way binding syntax INTRODUCED in v2.3 ALLOWS a child property to initialize an undefined parent property', function(){
+			var renderer = stache('<pa-rent/>');
+
+			Component.extend({
+			 tag : 'pa-rent',
+			 view: stache('<chi-ld childProp:bind="parentProp" />')
+		 });
+
+			Component.extend({
+			 tag : 'chi-ld',
+			 ViewModel: {
 				childProp: { value: 'bar' }
-            }
+			}
 		});
 
-		var frag = renderer({});
+			var frag = renderer({});
 
-		var parentVM = canViewModel(frag.firstChild);
-		var childVM = canViewModel(frag.firstChild.firstChild);
+			var parentVM = canViewModel(frag.firstChild);
+			var childVM = canViewModel(frag.firstChild.firstChild);
 
-		equal(parentVM.get("parentProp"), 'bar', 'parentProp is bar');
-		equal(childVM.get("childProp"), 'bar', 'childProp is bar');
+			equal(parentVM.get("parentProp"), 'bar', 'parentProp is bar');
+			equal(childVM.get("childProp"), 'bar', 'childProp is bar');
 
-		parentVM.set("parentProp",'foo');
+			parentVM.set("parentProp",'foo');
 
-		equal(parentVM.get("parentProp"), 'foo', 'parentProp is foo');
-		equal(childVM.get("childProp"), 'foo', 'childProp is foo');
+			equal(parentVM.get("parentProp"), 'foo', 'parentProp is foo');
+			equal(childVM.get("childProp"), 'foo', 'childProp is foo');
 
-		childVM.set("childProp",'baz');
+			childVM.set("childProp",'baz');
 
-		equal(parentVM.get("parentProp"), 'baz', 'parentProp is baz');
-		equal(childVM.get("childProp"), 'baz', 'childProp is baz');
-	});
-
-
-	test("conditional attributes (#2077)", function(){
-    
-		Component.extend({
-			tag: 'some-comp',
-            ViewModel: DefineMap.extend({ seal: false }, {})
+			equal(parentVM.get("parentProp"), 'baz', 'parentProp is baz');
+			equal(childVM.get("childProp"), 'baz', 'childProp is baz');
 		});
-		var renderer = stache("<some-comp "+
+
+
+		test("conditional attributes (#2077)", function(){
+			
+			Component.extend({
+			 tag: 'some-comp',
+			 ViewModel: DefineMap.extend({ seal: false }, {})
+		 });
+			var renderer = stache("<some-comp "+
 			"{{#if preview}}next:from='nextPage'{{/if}} "+
 			"swap:from='{{swapName}}' "+
 			"{{#preview}}checked{{/preview}} "+
 			"></some-comp>");
 
-		var map = new SimpleMap({
-			preview: true,
-			nextPage: 2,
-			swapName: "preview"
-		});
-		var frag = renderer(map);
+			var map = new SimpleMap({
+			 preview: true,
+			 nextPage: 2,
+			 swapName: "preview"
+		 });
+			var frag = renderer(map);
 
-		var vm = canViewModel(frag.firstChild);
+			var vm = canViewModel(frag.firstChild);
 
-		var threads = [
+			var threads = [
 			function(){
 
 				equal(vm.next, 2, "has binding");
 				equal(vm.swap, true, "swap - has binding");
 				//equal(vm.get("checked"), "", "attr - has binding"); (commented out because we don't do this sort of binding)
-                map.attr("preview", false);
+				map.attr("preview", false);
 			},
 			function(){
 				equal(vm.swap, false, "swap - updated binidng");
@@ -506,11 +506,11 @@ helpers.makeTests("can-component viewModels", function(){
 				map.attr("nextPage",4);
 				equal(vm.swap, 4, "swap - updated binding");
 			}
-		];
-		stop();
-		var index = 0;
-		var next = function(){
-			if(index < threads.length) {
+			];
+			stop();
+			var index = 0;
+			var next = function(){
+			 if(index < threads.length) {
 				threads[index]();
 				index++;
 				setTimeout(next, 150);
@@ -521,102 +521,102 @@ helpers.makeTests("can-component viewModels", function(){
 		setTimeout(next, 100);
 	});
 
-    QUnit.test("one-way - child to parent - parent that does not leak scope, but has no view", function(){
+		QUnit.test("one-way - child to parent - parent that does not leak scope, but has no view", function(){
 
-        Component.extend({
-            tag: "outer-noleak",
-            ViewModel: DefineMap.extend("Outer", {}, {
-                name: { default: "outer" },
-                myChild: { default: null }
-            }),
-            leakScope: false
-        });
-        Component.extend({
-            tag: "my-child",
-            ViewModel : DefineMap.extend("Inner", {}, {
-                name: { default: "inner" }
-            }),
-            leakScope: false
-        });
+			Component.extend({
+				tag: "outer-noleak",
+				ViewModel: DefineMap.extend("Outer", {}, {
+					name: { default: "outer" },
+					myChild: { default: null }
+				}),
+				leakScope: false
+			});
+			Component.extend({
+				tag: "my-child",
+				ViewModel : DefineMap.extend("Inner", {}, {
+					name: { default: "inner" }
+				}),
+				leakScope: false
+			});
 
-        var renderer = stache("<outer-noleak><my-child this:to='myChild'/></outer-noleak>");
-        var frag = renderer();
-        var vm = canViewModel(frag.firstChild);
-        QUnit.equal(vm.myChild.name,"inner", "got instance");
+			var renderer = stache("<outer-noleak><my-child this:to='myChild'/></outer-noleak>");
+			var frag = renderer();
+			var vm = canViewModel(frag.firstChild);
+			QUnit.equal(vm.myChild.name,"inner", "got instance");
 
-    });
-
-	QUnit.test("Can be called on an element using preventDataBindings (#183)", function(){
-		Component.extend({
-			tag: "prevent-data-bindings",
-			ViewModel: {},
-			view: stache("{{value}}")
 		});
 
-		var document = this.document;
-		var el = document.createElement("div");
-		var callback = tag("prevent-data-bindings");
+		QUnit.test("Can be called on an element using preventDataBindings (#183)", function(){
+			Component.extend({
+			 tag: "prevent-data-bindings",
+			 ViewModel: {},
+			 view: stache("{{value}}")
+		 });
 
-		var vm = new DefineMap({ value: "it worked" });
-		el[canSymbol.for('can.viewModel')] = vm;
-		canData.set.call(el, "preventDataBindings", true);
-		callback(el, {
-			scope: new Scope({ value: "it did not work" })
+			var document = this.document;
+			var el = document.createElement("div");
+			var callback = tag("prevent-data-bindings");
+
+			var vm = new DefineMap({ value: "it worked" });
+			el[canSymbol.for('can.viewModel')] = vm;
+			canData.set.call(el, "preventDataBindings", true);
+			callback(el, {
+			 scope: new Scope({ value: "it did not work" })
+		 });
+			canData.set.call(el, "preventDataBindings", false);
+
+			QUnit.equal(el.firstChild.nodeValue, "it worked");
 		});
-		canData.set.call(el, "preventDataBindings", false);
 
-		QUnit.equal(el.firstChild.nodeValue, "it worked");
-	});
-
-    QUnit.test("viewModel available as viewModel property (#282)", function() {
-		Component.extend({
-			tag: "can-map-viewmodel",
-			view: stache("{{name}}"),
-			viewModel: {
-        name: "Matthew"
+		QUnit.test("viewModel available as viewModel property (#282)", function() {
+			Component.extend({
+			 tag: "can-map-viewmodel",
+			 view: stache("{{name}}"),
+			 viewModel: {
+				name: "Matthew"
 			}
 		});
 
-		var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
+			var renderer = stache("<can-map-viewmodel></can-map-viewmodel>");
 
-		var fragOne = renderer();
-		var vmOne = fragOne.firstChild.viewModel;
+			var fragOne = renderer();
+			var vmOne = fragOne.firstChild.viewModel;
 
-		var fragTwo = renderer();
+			var fragTwo = renderer();
 
-		vmOne.set("name", "Wilbur");
+			vmOne.set("name", "Wilbur");
 
-		equal(fragOne.firstChild.firstChild.nodeValue, "Wilbur", "The first map changed values");
-		equal(fragTwo.firstChild.firstChild.nodeValue, "Matthew", "The second map did not change");
+			equal(fragOne.firstChild.firstChild.nodeValue, "Wilbur", "The first map changed values");
+			equal(fragTwo.firstChild.firstChild.nodeValue, "Matthew", "The second map did not change");
+		});
+
+		QUnit.test("connectedCallback without a disconnect calls stopListening", 1, function(){
+			QUnit.stop();
+
+			var map = new SimpleMap();
+
+			Component.extend({
+				tag: "connected-component-listen",
+				view: stache('rendered'),
+				ViewModel: {
+					connectedCallback: function(element) {
+						this.listenTo(map,"foo", function(){});
+					}
+				}
+			});
+			var template = stache("<connected-component-listen/>");
+			var frag = template();
+			var first = frag.firstChild;
+			domMutateNode.appendChild.call(this.fixture, frag);
+
+			helpers.afterMutation(function(){
+
+				domMutateNode.removeChild.call(first.parentNode, first);
+				helpers.afterMutation(function(){
+					QUnit.notOk( canReflect.isBound(map), "stopListening no matter what on vm");
+					QUnit.start();
+				});
+			});
+		});
+
 	});
-
-    QUnit.test("connectedCallback without a disconnect calls stopListening", 1, function(){
-        QUnit.stop();
-
-        var map = new SimpleMap();
-
-        Component.extend({
-            tag: "connected-component-listen",
-            view: stache('rendered'),
-            ViewModel: {
-                connectedCallback: function(element) {
-                    this.listenTo(map,"foo", function(){});
-                }
-            }
-        });
-        var template = stache("<connected-component-listen/>");
-        var frag = template();
-        var first = frag.firstChild;
-        domMutateNode.appendChild.call(this.fixture, frag);
-
-        helpers.afterMutation(function(){
-
-            domMutateNode.removeChild.call(first.parentNode, first);
-            helpers.afterMutation(function(){
-                QUnit.notOk( canReflect.isBound(map), "stopListening no matter what on vm");
-                QUnit.start();
-            });
-        });
-    });
-
-});

--- a/test/component-viewmodel-test.js
+++ b/test/component-viewmodel-test.js
@@ -206,12 +206,9 @@ helpers.makeTests("can-component viewModels", function(){
 		} else {
 			ok(false, "(getter) You've called the callback " + timesComputeIsCalled + " times");
 		}
-
-		console.log("Getting, " + sourceAge.get());
 		return sourceAge.get();
 
 	}, function(newVal){
-		console.log("Setting, " + newVal)
 		timesComputeIsCalled++;
 		if (timesComputeIsCalled === 2) {
 			ok(true, "updating value to " + newVal);

--- a/test/component-viewmodel-test.js
+++ b/test/component-viewmodel-test.js
@@ -204,7 +204,6 @@ helpers.makeTests("can-component viewModels", function(){
 			} else if (timesComputeIsCalled === 3) {
 				ok(true, "called back another time after set to get the value");
 			} else {
-          debugger;
                 ok(false, "(getter) You've called the callback " + timesComputeIsCalled + " times");
             }
 

--- a/test/component-viewmodel-test.js
+++ b/test/component-viewmodel-test.js
@@ -202,19 +202,22 @@ helpers.makeTests("can-component viewModels", function(){
 			if (timesComputeIsCalled === 1) {
 				ok(true, "reading initial value to set as years");
 			} else if (timesComputeIsCalled === 3) {
-				ok(true, "updating value to 31");
+				ok(true, "called back another time after set to get the value");
 			} else {
-                ok(false, "You've called the callback " + timesComputeIsCalled + " times");
+          debugger;
+                ok(false, "(getter) You've called the callback " + timesComputeIsCalled + " times");
             }
 
+      console.log("Getting, " + sourceAge.get());
 			return sourceAge.get();
 
 		}, function(newVal){
+      console.log("Setting, " + newVal)
             timesComputeIsCalled++;
             if (timesComputeIsCalled === 2) {
-				ok(true, "called back another time after set to get the value");
+				ok(true, "updating value to " + newVal);
 			} else {
-				ok(false, "You've called the callback " + timesComputeIsCalled + " times");
+				ok(false, "(setter) You've called the callback " + timesComputeIsCalled + " times");
 			}
             sourceAge.set(newVal);
         });
@@ -455,9 +458,10 @@ helpers.makeTests("can-component viewModels", function(){
 
 
 	test("conditional attributes (#2077)", function(){
+    
 		Component.extend({
 			tag: 'some-comp',
-            ViewModel: observe.Object.extend({})
+            ViewModel: DefineMap.extend({ seal: false }, {})
 		});
 		var renderer = stache("<some-comp "+
 			"{{#if preview}}next:from='nextPage'{{/if}} "+
@@ -522,19 +526,19 @@ helpers.makeTests("can-component viewModels", function(){
 
         Component.extend({
             tag: "outer-noleak",
-            ViewModel: observe.Object.extend("Outer",{},{
-                name: "outer"
+            ViewModel: DefineMap.extend("Outer", {}, {
+                name: { default: "outer" },
+                myChild: { default: null }
             }),
             leakScope: false
         });
         Component.extend({
             tag: "my-child",
-            ViewModel : observe.Object.extend("Inner",{},{
-                name: "inner"
+            ViewModel : DefineMap.extend("Inner", {}, {
+                name: { default: "inner" }
             }),
             leakScope: false
         });
-
 
         var renderer = stache("<outer-noleak><my-child this:to='myChild'/></outer-noleak>");
         var frag = renderer();
@@ -554,7 +558,7 @@ helpers.makeTests("can-component viewModels", function(){
 		var el = document.createElement("div");
 		var callback = tag("prevent-data-bindings");
 
-		var vm = new observe.Object({ value: "it worked" });
+		var vm = new DefineMap({ value: "it worked" });
 		el[canSymbol.for('can.viewModel')] = vm;
 		canData.set.call(el, "preventDataBindings", true);
 		callback(el, {
@@ -570,7 +574,7 @@ helpers.makeTests("can-component viewModels", function(){
 			tag: "can-map-viewmodel",
 			view: stache("{{name}}"),
 			viewModel: {
-                name: "Matthew"
+        name: "Matthew"
 			}
 		});
 


### PR DESCRIPTION
This rolls up the changes for `can-component` I've made so far in order to get tests to _run_ (but not necessarily _pass_) in IE11. They're mostly inconsenquential, but it does change from `element.ownerDocument.contains()` to `element.ownerDocument.documentElement.contains()`, which may have VDOM implications (and will need to be changed in a lot of other modules as well).