### PR TITLE
minor test cleanup, makes `new Component()` not observable

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -29,6 +29,7 @@ var DefineMap = require("can-define/map/map");
 var canLog = require('can-log');
 var canDev = require('can-log/dev/dev');
 var assign = require('can-assign');
+var ObservationRecorder = require("can-observation-recorder");
 require('can-view-model');
 
 // DefineList must be imported so Arrays on the ViewModel
@@ -160,7 +161,7 @@ function makeInsertionTagCallback(tagName, componentTagData, shadowTagData, leak
 // function and returning a function that can be used to set up the bindings
 function getSetupFunctionForComponentVM(componentInitVM) {
 	// componentInitVM is the viewModel in `new ComponentConstructor({ viewModel: {...} })`
-	return function(el, makeViewModel, initialVMData) {
+	return ObservationRecorder.ignore(function(el, makeViewModel, initialVMData) {
 		var onCompleteBindings = [];
 		var onTeardowns = [];
 		var viewModel;// This will be created after getting all the initial values
@@ -233,7 +234,7 @@ function getSetupFunctionForComponentVM(componentInitVM) {
 				onTeardown();
 			});
 		};
-	};
+	});
 }
 
 var Component = Construct.extend(

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "can-log": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^4.0.0",
+    "can-observation-recorder": "^1.2.0",
     "can-queues": "^1.0.0",
     "can-reflect": "^1.6.0",
     "can-simple-map": "^4.1.0",

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -273,13 +273,12 @@ QUnit.test("Component binding instantiation works as documented", function() {
 
 	// Create a new instance of our component
 	var componentInstance = new NameComponent({
-	  viewModel: {
-	    givenName: value.from(appVM, "family.first"),
-	    familyName: value.bind(appVM, "family.last"),
-	    fullName: value.to(appVM, "family.full")
-	  }
+		viewModel: {
+			givenName: value.from(appVM, "family.first"),
+			familyName: value.bind(appVM, "family.last"),
+			fullName: value.to(appVM, "family.full")
+		}
 	});
-	var element = componentInstance.element;
 	var viewModel = componentInstance.viewModel;
 
 	// Initial component values are correct
@@ -292,4 +291,44 @@ QUnit.test("Component binding instantiation works as documented", function() {
 	QUnit.equal(family.get("last"), "Flanders", "map “bind” prop is correct");
 	QUnit.equal(family.get("first"), "Milo", "map “from” prop is correct");
 	QUnit.equal(family.get("full"), "Milo Flanders", "map “to” prop is correct");
+});
+
+QUnit.test("component instantiation is not observable", function(){
+
+	var innerViewModel;
+	var InnerComponent = Component.extend({
+		tag: "inner-component-to-make",
+		view: "{{this.innerValue}}",
+		ViewModel: {
+			init: function(){
+				innerViewModel = this;
+			},
+			innerValue: "any"
+		}
+	});
+
+	var count = 0;
+
+	Component.extend({
+		tag: "outer-component-creator",
+		view: "{{{ this.innerComponent }}}",
+		ViewModel: {
+			get innerComponent() {
+				count++;
+				return new InnerComponent({
+					viewModel: {
+						innerValue: value.bind(this, "outerValue")
+					}
+				});
+			},
+			outerValue: "any"
+		}
+	});
+
+	var view = stache("<outer-component-creator/>");
+	frag = view();
+
+	innerViewModel.innerValue = "SOME-VALUE";
+
+	QUnit.equal(count, 1, "only updated once");
 });

--- a/test/component-view-test.js
+++ b/test/component-view-test.js
@@ -71,8 +71,8 @@ helpers.makeTests("can-component views", function(doc, runTestInOnlyDocument){
 			leakScope: true,
 			view: stache("{{greeting}} <content>World</content>{{../exclamation}}"),
 			viewModel: function(){
-                return new SimpleMap({greeting: "Hello"});
-            }
+				return new SimpleMap({greeting: "Hello"});
+			}
 		});
 
 		var renderer = stache("<hello-world>{{greeting}}</hello-world>");

--- a/test/example-test.js
+++ b/test/example-test.js
@@ -73,7 +73,7 @@ helpers.makeTests("can-component examples", function(doc) {
 
 	test("treecombo", function() {
 
-		var TreeComboViewModel = DefineMap.extend({
+		var TreeComboViewModel = DefineMap.extend("TreeComboViewModel",{
 			items: {
 				Default: DefineList
 			},
@@ -150,8 +150,8 @@ helpers.makeTests("can-component examples", function(doc) {
 		});
 
 		var renderer = stache("<treecombo items:bind='locations' title:from='\"Locations\"'></treecombo>");
-
-		var base = new DefineMap({});
+		var BaseViewModel = DefineMap.extend("BaseViewModel",{seal: false},{});
+		var base = new BaseViewModel({});
 
 		var frag = renderer(base);
 		var root = doc.createElement("div");
@@ -222,7 +222,6 @@ helpers.makeTests("can-component examples", function(doc) {
 		stop();
 
 		setTimeout(function() {
-
 			base.set('locations', items);
 
 			var itemsList = base.get('locations');


### PR DESCRIPTION
when one does `new Component()` it's currently observable because `bind.parentValue` reads the parent observable.  

Thus if that value changes, any getter `new Component()` is in will re-run.  