### PR TITLE
changing key in test to something that doesn't conflict with IE11

### DIFF
--- a/test/component-events-test.js
+++ b/test/component-events-test.js
@@ -181,12 +181,12 @@ helpers.makeTests("can-component events", function(){
 			tag: 'rebind-viewmodel',
 			events: {
 				init: function(){
-					this.viewModel.set("item" , new SimpleMap({}) );
+					this.viewModel.set("anItem" , new SimpleMap({}) );
 				},
-				'{scope.item} name': function() {
+				'{scope.anItem} name': function() {
 					ok(true, 'Change event on scope');
 				},
-				'{viewModel.item} name': function() {
+				'{viewModel.anItem} name': function() {
 					ok(true, 'Change event on viewModel');
 				}
 			}
@@ -195,7 +195,7 @@ helpers.makeTests("can-component events", function(){
 		var rebind = frag.firstChild;
 		domMutateNode.appendChild.call(this.fixture, rebind);
 
-		canViewModel(rebind).get("item").set('name', 'CDN');
+		canViewModel(rebind).get("anItem").set('name', 'CDN');
 	});
 
 


### PR DESCRIPTION
`window.item` exists in IE11, which causes this test to break in IE11
because can-control sets up event binding on the window instead of the
ViewModel.

part of https://github.com/canjs/canjs/issues/4115.