### PR TITLE
Teardown bindings when a nodeList in unregistered

### DIFF
--- a/benchmark/memory.html
+++ b/benchmark/memory.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<title>Memory tests</title>
+<button type="button">Run me</button>
+<div id="root"></div>
+<script src="../node_modules/steal/steal.js"></script>
+<script type="steal-module">
+	var Component = require("can-component");
+	var nodeLists = require("can-view-nodelist");
+
+	var MyComponent = Component.extend({
+		tag: "my-thing",
+		view: "Hello world"
+	});
+
+	function run() {
+		var inst = new MyComponent();
+		nodeLists.unregister(inst.nodeList);
+	}
+
+	document.querySelector('button').addEventListener('click', run);
+</script>

--- a/can-component.js
+++ b/can-component.js
@@ -557,8 +557,13 @@ var Component = Construct.extend(
 					var doc = el.ownerDocument;
 					var rootNode = doc.contains ? doc : doc.documentElement;
 					if (!rootNode || !rootNode.contains(el)) {
-						removalDisposal();
-						callTeardownFunctions();
+						if(removalDisposal) {
+							nodeRemoved = true;
+							removalDisposal();
+							callTeardownFunctions();
+							removalDisposal = null;
+							callTeardownFunctions = null;
+						}
 					}
 				});
 			}
@@ -623,11 +628,12 @@ var Component = Construct.extend(
 				betweenTagsView = componentTagData.subtemplate || el.ownerDocument.createDocumentFragment.bind(el.ownerDocument);
 			}
 			var viewModelDisconnectedCallback,
-				componentInPage;
+				componentInPage,
+				nodeRemoved;
 
 			// Keep a nodeList so we can kill any directly nested nodeLists within this component
 			var nodeList = nodeLists.register([], function() {
-				if(removalDisposal) {
+				if(removalDisposal && !nodeRemoved) {
 					removalDisposal();
 					callTeardownFunctions();
 					removalDisposal = null;

--- a/can-component.js
+++ b/can-component.js
@@ -132,7 +132,6 @@ function makeReplacementTagCallback(tagName, componentTagData, shadowTagData, le
 	// - `el` - the element
 	// - `insertionElementTagData` - the tagData where the element was found.
 	return function replacementTag(el, insertionElementTagData) {
-
 		// If there's no template to be rendered, we'll render what's inside the
 		// element. This is usually default content.
 		var template = getPrimaryTemplate(el) || insertionElementTagData.subtemplate,
@@ -178,8 +177,9 @@ function makeReplacementTagCallback(tagName, componentTagData, shadowTagData, le
 			// We need to teardown any bindings created too so we create a nodeList
 			// to do this.
 
-			var nodeList = nodeLists.register([el],
-				tagData.teardown || noop,
+
+
+			var nodeList = nodeLists.register([el], tagData.teardown || noop,
 				insertionElementTagData.parentNodeList || true,
 				insertionElementTagData.directlyNested);
 
@@ -627,6 +627,12 @@ var Component = Construct.extend(
 
 			// Keep a nodeList so we can kill any directly nested nodeLists within this component
 			var nodeList = nodeLists.register([], function() {
+				if(removalDisposal) {
+					removalDisposal();
+					callTeardownFunctions();
+					removalDisposal = null;
+					callTeardownFunctions = null;
+				}
 				component._torndown = true;
 				domEvents.dispatch(el, "beforeremove", false);
 				if(teardownBindings) {


### PR DESCRIPTION
This handles the case where a component is created via `new Component()`
but the instance is never inserted into the dom. When this happens it
means that listeners set up by `domMutate.onNodeRemoval` need to be
removed via nodeLists, which is what this does.