### PR TITLE
Add support for initializeBindings: false

### DIFF
--- a/benchmark/memory2.html
+++ b/benchmark/memory2.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<title>Memory tests</title>
+<button type="button">Run me</button>
+<div id="root"></div>
+<script src="../node_modules/steal/steal.js"></script>
+<script type="steal-module">
+	var DefineMap = require("can-define/map/map");
+	var Component = require("can-component");
+	var nodeLists = require("can-view-nodelist");
+	var domMutateNode = require("can-dom-mutate/node");
+	var stache = require("can-stache");
+
+	var MyComponent = Component.extend({
+		tag: "my-thing",
+		view: "Hello world",
+		ViewModel: { count: "number" }
+	});
+
+	var ViewModel = DefineMap.extend({
+		count: { default: 0 },
+
+		get component() {
+			var count = this.count;
+
+			if(count === 2) {
+				return document.createElement('div');
+			}
+
+
+			var comp = new MyComponent({ count });
+			return Promise.resolve(comp);
+		}
+	});
+
+	async function run() {
+		var vm = new ViewModel();
+		var frag = stache(`
+			<span>Count: {{count}}</span>
+			{{#if(component.isResolved)}}
+				<div>{{component.value}}</div>
+			{{/if}}
+		`)(vm);
+
+		vm.count++;
+
+		setTimeout(() => {
+			vm.count++;
+
+			domMutateNode.appendChild.call(root, frag);
+			setTimeout(() => {
+				while(root.firstChild) {
+					domMutateNode.removeChild.call(root, root.firstChild);
+				}
+			}, 100)
+		}, 100);
+	}
+
+	document.querySelector('button').addEventListener('click', run);
+</script>

--- a/can-component.js
+++ b/can-component.js
@@ -438,6 +438,13 @@ var Component = Construct.extend(
 			}
 			this.element = el;
 
+			if(componentTagData.initializeBindings === false && !this._skippedSetup) {
+				// Temporary, will be overridden.
+				this._skippedSetup = this._torndown = true;
+				this.viewModel = Object.create(null);
+				return;
+			}
+
 			var componentContent = componentTagData.content;
 			if (componentContent !== undefined) {
 				// Check if it’s already a renderer function or

--- a/docs/new-component.md
+++ b/docs/new-component.md
@@ -327,3 +327,27 @@ This makes `helloWorldInstance.element` a fragment with the following structure:
 ```html
 <hello-world>Hello <em>mundo</em></hello-world>
 ```
+
+### initializeBindings
+
+By default bindings are initialized when a component is created. For most components this is what you want. However if you are only conditionally inserting a component it can leak memory if bindings are setup. Setting `initializeBindings: false` prevents the setting up of bindings until the component is inserted into a view.
+
+```js
+import {Component, stache} from "can";
+
+const HelloWorld = Component.extend({
+  tag: "hello-world",
+  view: "Hello world"
+});
+
+const helloWorldInstance = new HelloWorld({
+  initializeBindings: false
+});
+
+// Bindings are not setup.
+
+const view = stache("{{component}}");
+document.body.append(view({ component: helloWorldInstance }));
+
+// Now they are!
+```

--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -357,3 +357,25 @@ QUnit.test("Can render in a document with no body", function() {
 		globals.setKeyValue("document", document);
 	}
 });
+
+QUnit.test("{initializeBindings: false} prevents setting up bindings until insert", function() {
+	var ComponentConstructor = Component.extend({
+		tag: "some-random-tag",
+		view: "{{color}}",
+		ViewModel: {
+			color: { default: "red" }
+		}
+	});
+
+	var inst = new ComponentConstructor({
+		initializeBindings: false
+	});
+
+	QUnit.equal(inst.viewModel.color, undefined, "ViewModel not yet setup");
+
+	var view = stache("{{component}}");
+	var frag = view({ component: inst });
+
+	QUnit.equal(inst.viewModel.color, "red", "is red");
+	QUnit.equal(frag.firstElementChild.firstChild.data, "red", "Now it is setup");
+});


### PR DESCRIPTION
This adds support for initializeBindings: false as an argument to the
component constructor.

The effect is that component setup will be deferred until after the
viewInsertSymbol is called (by can-view-live). This is useful when
constructing components and conditionally inserting them.

Fixes #278 