### PR TITLE
Fix test to run in IE11

### DIFF
--- a/test/component-instantiation-test.js
+++ b/test/component-instantiation-test.js
@@ -377,5 +377,5 @@ QUnit.test("{initializeBindings: false} prevents setting up bindings until inser
 	var frag = view({ component: inst });
 
 	QUnit.equal(inst.viewModel.color, "red", "is red");
-	QUnit.equal(frag.firstElementChild.firstChild.data, "red", "Now it is setup");
+	QUnit.equal(frag.firstChild.firstChild.data, "red", "Now it is setup");
 });


### PR DESCRIPTION
This fixes a test that was using `el.firstElementChild` to use
`firstChild` instead because the former is not available in IE11.