### PR TITLE
logStack include component instantiation mutations

### DIFF
--- a/can-component.js
+++ b/can-component.js
@@ -495,13 +495,8 @@ var Component = Construct.extend(
 
 					//!steal-remove-start
 					if (process.env.NODE_ENV !== 'production') {
-						Object.defineProperty(setupFn, "name",{
-							value: "render <"+this.tag+">",
-							configurable: true
-						});
-
 						setupFn = queues.runAsTask(setupFn, function(el, componentTagData) {
-							return ["Rendering", el, "with",el, componentTagData.viewModel];
+							return ["Constructing", el, "with viewModel",componentTagData.viewModel];
 						});
 					}
 					//!steal-remove-end

--- a/can-component.js
+++ b/can-component.js
@@ -492,9 +492,24 @@ var Component = Construct.extend(
 				} else if (componentTagData.viewModel) {
 					// Component is being instantiated with a viewModel
 					setupFn = getSetupFunctionForComponentVM(componentTagData.viewModel);
+
+					//!steal-remove-start
+					if (process.env.NODE_ENV !== 'production') {
+						Object.defineProperty(setupFn, "name",{
+							value: "render <"+this.tag+">",
+							configurable: true
+						});
+
+						setupFn = queues.runAsTask(setupFn, function(el, componentTagData) {
+							return ["Rendering", el, "with",el, componentTagData.viewModel];
+						});
+					}
+					//!steal-remove-end
 				} else {
 					setupFn = stacheBindings.behaviors.viewModel;
 				}
+
+
 				teardownBindings = setupFn(el, componentTagData, function(initialViewModelData) {
 
 					var ViewModel = component.constructor.ViewModel,

--- a/test/component-can-bind-test.js
+++ b/test/component-can-bind-test.js
@@ -88,7 +88,7 @@ testHelpers.dev.devOnlyTest("logStack should include `new Component()` mutations
 
 	new ComponentConstructor({
 		viewModel : {
-			foo: value.bind(this,"bar")
+			foo: "bar"
 		}
 	});
 });

--- a/test/component-can-bind-test.js
+++ b/test/component-can-bind-test.js
@@ -4,6 +4,8 @@ var helpers = require("./helpers");
 var QUnit = require("steal-qunit");
 var SimpleMap = require("can-simple-map");
 var value = require("can-value");
+var queues = require("can-queues");
+var testHelpers = require("can-test-helpers");
 
 QUnit.module("can-component integration with can-bind");
 
@@ -68,5 +70,25 @@ QUnit.test("Using can-bind in connectedCallback works as documented", function(a
 		fixture.removeChild(element);
 
 		done();
+	});
+});
+
+testHelpers.dev.devOnlyTest("logStack should include `new Component()` mutations", function(assert) {
+	var ComponentConstructor = Component.extend({
+		tag: "a-tag",
+		view: '{{foo}}',
+		ViewModel: {
+			setup: function () {
+				var expected = queues.stack().length > 0;
+				assert.ok(expected, "At least one task on the stack");
+			},
+			foo: 'string'
+		}
+	});
+
+	new ComponentConstructor({
+		viewModel : {
+			foo: value.bind(this,"bar")
+		}
 	});
 });


### PR DESCRIPTION
Fixes #358 

### The changes:
Run a `can-queues` task a When the component is instantiated with `viewModel` (lowercase v).