### PR TITLE
behave like can-stache-element to create a renderer from passed view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 12
 addons:
   firefox: latest
 dist: xenial

--- a/can-component.js
+++ b/can-component.js
@@ -380,9 +380,9 @@ var Component = Construct.extend(
 				}
 				
 				var viewName = string.capitalize( string.camelize(this.prototype.tag) )+"View";
-				this.view = typeof this.view === "function" ?
-					this.view :
-					stache(viewName, this.view || "");
+				if(this.view !== undefined && typeof this.view !== "function"){
+					this.view = stache(viewName, this.view || "");
+				}
 
 				var renderComponent = function(el, tagData) {
 					// Check if a symbol already exists on the element; if it does, then

--- a/can-component.js
+++ b/can-component.js
@@ -378,15 +378,11 @@ var Component = Construct.extend(
 				if (this.prototype.view) {
 					this.view = this.prototype.view;
 				}
-
-				// default to stache if renderer is a string
-				if (typeof this.view === "string") {
-					var viewName = string.capitalize( string.camelize(this.prototype.tag) )+"View";
-					this.view = stache(viewName, this.view);
-				}
-
-				// TODO: Remove in next release.
-				this.renderer = this.view;
+				
+				var viewName = string.capitalize( string.camelize(this.prototype.tag) )+"View";
+				this.view = typeof this.view === "function" ?
+					this.view :
+					stache(viewName, this.view || "");
 
 				var renderComponent = function(el, tagData) {
 					// Check if a symbol already exists on the element; if it does, then

--- a/can-component.js
+++ b/can-component.js
@@ -379,8 +379,9 @@ var Component = Construct.extend(
 					this.view = this.prototype.view;
 				}
 				
-				var viewName = string.capitalize( string.camelize(this.prototype.tag) )+"View";
+				var viewName;
 				if(this.view !== undefined && typeof this.view !== "function"){
+					viewName = string.capitalize( string.camelize(this.prototype.tag) )+"View";
 					this.view = stache(viewName, this.view || "");
 				}
 


### PR DESCRIPTION
this PR changes the behavior for creating a renderer.
in `can-stache-element` [link](https://github.com/canjs/can-stache-element/blob/9465e6d04924e3d075f2e0ae8d17622119bb844e/src/mixin-stache-view.js#L27-L32) checks if the view is a function (renderer function). 
`can-component` behaved different. it checked for view beeing a string. 
https://github.com/canjs/can-component/blob/master/can-component.js#L383-L385

this is a breaking change, but the current documentation is still correct. so maybe this isn't worth to create a major release.
https://canjs.com/doc/can-component.prototype.view.html

this close https://github.com/canjs/can-component/issues/371
